### PR TITLE
J01 35 be 컴포넌트 기능

### DIFF
--- a/src/main/java/ject/componote/domain/auth/application/AuthService.java
+++ b/src/main/java/ject/componote/domain/auth/application/AuthService.java
@@ -39,7 +39,7 @@ public class AuthService {
         }
 
         final Member member = memberRepository.save(request.toMember());
-        fileService.moveImage(member.getProfileImage().getImage()); // 맘에 안듬...
+        fileService.moveImage(member.getProfileImage());
         return MemberSignupResponse.from(member);
     }
 

--- a/src/main/java/ject/componote/domain/auth/application/MemberService.java
+++ b/src/main/java/ject/componote/domain/auth/application/MemberService.java
@@ -37,7 +37,7 @@ public class MemberService {
             return;
         }
 
-        fileService.moveImage(profileImage.getImage());
+        fileService.moveImage(profileImage);
         member.updateProfileImage(profileImage);
         memberRepository.save(member);
     }

--- a/src/main/java/ject/componote/domain/auth/dto/find/response/MemberSummaryResponse.java
+++ b/src/main/java/ject/componote/domain/auth/dto/find/response/MemberSummaryResponse.java
@@ -6,7 +6,7 @@ public record MemberSummaryResponse(String nickname, String profileImageUrl) {
     public static MemberSummaryResponse from(MemberSummaryDao memberSummaryDao) {
         return new MemberSummaryResponse(
                 memberSummaryDao.nickname().getValue(),
-                memberSummaryDao.profileImage().getImage().toUrl()
+                memberSummaryDao.profileImage().toUrl()
         );
     }
 }

--- a/src/main/java/ject/componote/domain/auth/model/ProfileImage.java
+++ b/src/main/java/ject/componote/domain/auth/model/ProfileImage.java
@@ -1,26 +1,22 @@
 package ject.componote.domain.auth.model;
 
 import ject.componote.domain.auth.error.InvalidProfileImageExtensionException;
-import ject.componote.domain.common.model.BaseImage;
+import ject.componote.domain.common.model.AbstractImage;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.ToString;
 import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
 
-@EqualsAndHashCode
-@Getter
+@EqualsAndHashCode(callSuper = true)
 @ToString
-public class ProfileImage {
+public class ProfileImage extends AbstractImage {
     private static final List<String> ALLOWED_IMAGE_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png");
     private static final ProfileImage DEFAULT_PROFILE_IMAGE = ProfileImage.from("/profiles/default-profile-image.png");
 
-    private final BaseImage image;
-
-    private ProfileImage(final BaseImage image) {
-        this.image = image;
+    public ProfileImage(final String objectKey) {
+        super(objectKey);
     }
 
     public static ProfileImage from(final String objectKey) {
@@ -33,6 +29,6 @@ public class ProfileImage {
             throw new InvalidProfileImageExtensionException(extension);
         }
 
-        return new ProfileImage(BaseImage.from(objectKey));
+        return new ProfileImage(objectKey);
     }
 }

--- a/src/main/java/ject/componote/domain/auth/model/converter/ProfileImageConverter.java
+++ b/src/main/java/ject/componote/domain/auth/model/converter/ProfileImageConverter.java
@@ -8,8 +8,7 @@ import ject.componote.domain.auth.model.ProfileImage;
 public class ProfileImageConverter implements AttributeConverter<ProfileImage, String> {
     @Override
     public String convertToDatabaseColumn(final ProfileImage attribute) {
-        return attribute.getImage()
-                .getObjectKey();
+        return attribute.getObjectKey();
     }
 
     @Override

--- a/src/main/java/ject/componote/domain/bookmark/dao/BookmarkRepository.java
+++ b/src/main/java/ject/componote/domain/bookmark/dao/BookmarkRepository.java
@@ -1,0 +1,8 @@
+package ject.componote.domain.bookmark.dao;
+
+import ject.componote.domain.bookmark.domain.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+    boolean existsByComponentIdAndMemberId(final Long componentId, final Long memberId);
+}

--- a/src/main/java/ject/componote/domain/comment/application/CommentService.java
+++ b/src/main/java/ject/componote/domain/comment/application/CommentService.java
@@ -46,7 +46,7 @@ public class CommentService {
         final Comment comment = commentRepository.save(
                 CommentCreationStrategy.createBy(request, authPrincipal.id())
         );
-        fileService.moveImage(comment.getImage().getImage());
+        fileService.moveImage(comment.getImage());
         return CommentCreateResponse.from(comment);
     }
 
@@ -72,7 +72,7 @@ public class CommentService {
 
         final CommentImage image = CommentImage.from(commentUpdateRequest.imageObjectKey());
         if (!comment.equalsImage(image)) {
-            fileService.moveImage(image.getImage());
+            fileService.moveImage(image);
         }
 
         final CommentContent content = CommentContent.from(commentUpdateRequest.content()); // 가비지가 발생하지 않을까?

--- a/src/main/java/ject/componote/domain/comment/dto/find/response/CommentFindByComponentResponse.java
+++ b/src/main/java/ject/componote/domain/comment/dto/find/response/CommentFindByComponentResponse.java
@@ -19,7 +19,7 @@ public record CommentFindByComponentResponse(
                 createProfileResponse(dto),
                 dto.commentId(),
                 dto.parentId(),
-                dto.commentImage().getImage().toUrl(),
+                dto.commentImage().toUrl(),
                 dto.content().getValue(),
                 dto.createdAt(),
                 dto.likeCount().getValue(),
@@ -31,7 +31,7 @@ public record CommentFindByComponentResponse(
         return new CommentProfileResponse(
                 dto.memberId(),
                 dto.nickname().getValue(),
-                dto.profileImage().getImage().toUrl(),
+                dto.profileImage().toUrl(),
                 dto.job().name()
         );
     }

--- a/src/main/java/ject/componote/domain/comment/model/CommentImage.java
+++ b/src/main/java/ject/componote/domain/comment/model/CommentImage.java
@@ -1,30 +1,27 @@
 package ject.componote.domain.comment.model;
 
 import ject.componote.domain.comment.error.InvalidCommentImageExtensionException;
-import ject.componote.domain.common.model.BaseImage;
+import ject.componote.domain.common.model.AbstractImage;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.ToString;
 import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
 
-@EqualsAndHashCode
-@Getter
+@EqualsAndHashCode(callSuper = true)
 @ToString
-public class CommentImage {
+public class CommentImage extends AbstractImage {
     private static final List<String> ALLOWED_IMAGE_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png", "gif");
+    private static final CommentImage EMPTY_INSTANCE = new CommentImage(null);
 
-    private final BaseImage image;
-
-    private CommentImage(final BaseImage image) {
-        this.image = image;
+    public CommentImage(final String objectKey) {
+        super(objectKey);
     }
 
     public static CommentImage from(final String objectKey) {
         if (objectKey == null || objectKey.isEmpty()) {
-            return new CommentImage(BaseImage.getEmptyInstance());
+            return EMPTY_INSTANCE;
         }
 
         final String extension = StringUtils.getFilenameExtension(objectKey);
@@ -32,6 +29,6 @@ public class CommentImage {
             throw new InvalidCommentImageExtensionException(extension);
         }
 
-        return new CommentImage(BaseImage.from(objectKey));
+        return new CommentImage(objectKey);
     }
 }

--- a/src/main/java/ject/componote/domain/comment/model/converter/CommentImageConverter.java
+++ b/src/main/java/ject/componote/domain/comment/model/converter/CommentImageConverter.java
@@ -8,8 +8,7 @@ import ject.componote.domain.comment.model.CommentImage;
 public class CommentImageConverter implements AttributeConverter<CommentImage, String> {
     @Override
     public String convertToDatabaseColumn(final CommentImage attribute) {
-        return attribute.getImage()
-                .getObjectKey();
+        return attribute.getObjectKey();
     }
 
     @Override

--- a/src/main/java/ject/componote/domain/common/model/AbstractImage.java
+++ b/src/main/java/ject/componote/domain/common/model/AbstractImage.java
@@ -1,0 +1,30 @@
+package ject.componote.domain.common.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@Getter
+@ToString
+public abstract class AbstractImage {
+    private static final String IMAGE_URL_PREFIX = "https://componote.s3.ap-northeast-2.amazonaws.com/permanent/";
+
+    private final String objectKey;
+
+    protected AbstractImage(final String objectKey) {
+        this.objectKey = objectKey;
+    }
+
+    public boolean isEmpty() {
+        return objectKey == null || objectKey.isEmpty();
+    }
+
+    public String toUrl() {
+        if (isEmpty()) {
+            return null;
+        }
+
+        return IMAGE_URL_PREFIX + objectKey;
+    }
+}

--- a/src/main/java/ject/componote/domain/common/model/BaseImage.java
+++ b/src/main/java/ject/componote/domain/common/model/BaseImage.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public class BaseImage {
-    private static final String IMAGE_URL_PREFIX = "https://componote.s3.ap-northeast-2.amazonaws.com/permanent";
+    private static final String IMAGE_URL_PREFIX = "https://componote.s3.ap-northeast-2.amazonaws.com/permanent/";
     private static final BaseImage EMPTY_INSTANCE = new BaseImage(null);
 
     private final String objectKey;

--- a/src/main/java/ject/componote/domain/component/api/ComponentController.java
+++ b/src/main/java/ject/componote/domain/component/api/ComponentController.java
@@ -1,0 +1,45 @@
+package ject.componote.domain.component.api;
+
+import jakarta.validation.Valid;
+import ject.componote.domain.auth.model.AuthPrincipal;
+import ject.componote.domain.auth.model.Authenticated;
+import ject.componote.domain.common.dto.response.PageResponse;
+import ject.componote.domain.component.application.ComponentService;
+import ject.componote.domain.component.dto.find.request.ComponentSearchRequest;
+import ject.componote.domain.component.dto.find.response.ComponentSummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/components")
+@RequiredArgsConstructor
+@RestController
+public class ComponentController {
+    private final ComponentService componentService;
+
+    @GetMapping("/search")
+    public ResponseEntity<PageResponse<ComponentSummaryResponse>> search(
+            @Authenticated final AuthPrincipal authPrincipal,
+            @ModelAttribute @Valid final ComponentSearchRequest request,
+            @PageableDefault final Pageable pageable
+            ) {
+        return ResponseEntity.ok(
+                componentService.search(authPrincipal, request, pageable)
+        );
+    }
+
+    @GetMapping("/{componentId}")
+    public ResponseEntity<?> getComponentDetail(
+            @Authenticated final AuthPrincipal authPrincipal,
+            @PathVariable("componentId") final Long componentId) {
+        return ResponseEntity.ok(
+                componentService.getComponentDetail(authPrincipal, componentId)
+        );
+    }
+}

--- a/src/main/java/ject/componote/domain/component/application/ComponentSearchStrategy.java
+++ b/src/main/java/ject/componote/domain/component/application/ComponentSearchStrategy.java
@@ -1,0 +1,67 @@
+package ject.componote.domain.component.application;
+
+import ject.componote.domain.auth.model.AuthPrincipal;
+import ject.componote.domain.component.dao.ComponentRepository;
+import ject.componote.domain.component.dao.ComponentSummaryDao;
+import ject.componote.domain.component.dto.find.request.ComponentSearchRequest;
+import ject.componote.domain.component.error.InvalidCommentSearchStrategyException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Arrays;
+import java.util.function.BiPredicate;
+
+@RequiredArgsConstructor
+public enum ComponentSearchStrategy {
+    WITH_BOOKMARK_AND_FILTER(
+            (authPrincipal, request) -> isLoggedIn(authPrincipal) && hasFilter(request),
+            (authPrincipal, componentRepository, request, pageable) ->
+                    componentRepository.searchWithBookmarkAndTypes(authPrincipal.id(), request.keyword(), request.types(), pageable)
+    ),
+
+    WITH_BOOKMARK(
+            (authPrincipal, request) -> isLoggedIn(authPrincipal) && !hasFilter(request),
+            (authPrincipal, componentRepository, request, pageable) ->
+                    componentRepository.searchWithBookmark(authPrincipal.id(), request.keyword(), pageable)
+    ),
+
+    WITHOUT_BOOKMARK_AND_FILTER(
+            (authPrincipal, request) -> !isLoggedIn(authPrincipal) && hasFilter(request),
+            (authPrincipal, componentRepository, request, pageable) ->
+                    componentRepository.searchByKeywordWithTypes(request.keyword(), request.types(), pageable)
+    ),
+
+    WITHOUT_BOOKMARK(
+            (authPrincipal, request) -> !isLoggedIn(authPrincipal) && !hasFilter(request),
+            (authPrincipal, componentRepository, request, pageable) ->
+                    componentRepository.searchByKeyword(request.keyword(), pageable)
+    );
+
+    private final BiPredicate<AuthPrincipal, ComponentSearchRequest> condition;
+    private final ComponentSearchFunction searchFunction;
+
+    public static Page<ComponentSummaryDao> searchBy(final AuthPrincipal authPrincipal,
+                                                     final ComponentRepository componentRepository,
+                                                     final ComponentSearchRequest request,
+                                                     final Pageable pageable) {
+        return Arrays.stream(values())
+                .filter(strategy -> strategy.condition.test(authPrincipal, request))
+                .findFirst()
+                .orElseThrow(InvalidCommentSearchStrategyException::new)
+                .searchFunction.search(authPrincipal, componentRepository, request, pageable);
+    }
+
+    private static boolean isLoggedIn(final AuthPrincipal authPrincipal) {
+        return authPrincipal != null;
+    }
+
+    private static boolean hasFilter(final ComponentSearchRequest request) {
+        return request.types() != null && !request.types().isEmpty();
+    }
+
+    @FunctionalInterface
+    private interface ComponentSearchFunction {
+        Page<ComponentSummaryDao> search(final AuthPrincipal authPrincipal, final ComponentRepository componentRepository, final ComponentSearchRequest request, final Pageable pageable);
+    }
+}

--- a/src/main/java/ject/componote/domain/component/application/ComponentService.java
+++ b/src/main/java/ject/componote/domain/component/application/ComponentService.java
@@ -1,0 +1,57 @@
+package ject.componote.domain.component.application;
+
+import ject.componote.domain.auth.model.AuthPrincipal;
+import ject.componote.domain.bookmark.dao.BookmarkRepository;
+import ject.componote.domain.common.dto.response.PageResponse;
+import ject.componote.domain.component.dao.ComponentRepository;
+import ject.componote.domain.component.domain.Component;
+import ject.componote.domain.component.dto.find.event.ComponentViewCountIncreaseEvent;
+import ject.componote.domain.component.dto.find.request.ComponentSearchRequest;
+import ject.componote.domain.component.dto.find.response.ComponentDetailResponse;
+import ject.componote.domain.component.dto.find.response.ComponentSummaryResponse;
+import ject.componote.domain.component.error.NotFoundComponentException;
+import ject.componote.domain.component.util.ComponentMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ComponentService {
+    private final ApplicationEventPublisher eventPublisher;
+    private final BookmarkRepository bookmarkRepository;
+    private final ComponentMapper componentMapper;
+    private final ComponentRepository componentRepository;
+
+    public ComponentDetailResponse getComponentDetail(final AuthPrincipal authPrincipal, final Long componentId) {
+        final Component component = findComponentById(componentId);
+        eventPublisher.publishEvent(ComponentViewCountIncreaseEvent.from(component));
+        return componentMapper.mapFrom(component, isBookmarked(authPrincipal, componentId));
+    }
+
+    public PageResponse<ComponentSummaryResponse> search(final AuthPrincipal authPrincipal,
+                                                         final ComponentSearchRequest request,
+                                                         final Pageable pageable) {
+        final Page<ComponentSummaryResponse> page = ComponentSearchStrategy.searchBy(authPrincipal, componentRepository, request, pageable)
+                .map(ComponentSummaryResponse::from);
+        return PageResponse.from(page);
+    }
+
+    private Component findComponentById(final Long componentId) {
+        return componentRepository.findById(componentId)
+                .orElseThrow(() -> new NotFoundComponentException(componentId));
+    }
+
+    private boolean isBookmarked(final AuthPrincipal authPrincipal, final Long componentId) {
+        if (authPrincipal == null) {
+            return false;
+        }
+
+        final Long memberId = authPrincipal.id();
+        return bookmarkRepository.existsByComponentIdAndMemberId(componentId, memberId);
+    }
+}

--- a/src/main/java/ject/componote/domain/component/application/ComponentViewCountEventHandler.java
+++ b/src/main/java/ject/componote/domain/component/application/ComponentViewCountEventHandler.java
@@ -1,0 +1,30 @@
+package ject.componote.domain.component.application;
+
+import ject.componote.domain.component.dao.ComponentRepository;
+import ject.componote.domain.component.domain.Component;
+import ject.componote.domain.component.dto.find.event.ComponentViewCountIncreaseEvent;
+import ject.componote.domain.component.error.NotFoundComponentException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.annotation.Transactional;
+
+@org.springframework.stereotype.Component
+@RequiredArgsConstructor
+public class ComponentViewCountEventHandler {
+    private final ComponentRepository componentRepository;
+
+    @Async
+    @EventListener
+    @Transactional
+    public void handleViewCountIncrease(final ComponentViewCountIncreaseEvent event) {
+        final Long componentId = event.componentId();
+        final Component component = findComponentById(componentId);
+        component.increaseViewCount();
+    }
+
+    private Component findComponentById(final Long componentId) {
+        return componentRepository.findById(componentId)
+                .orElseThrow(() -> new NotFoundComponentException(componentId));
+    }
+}

--- a/src/main/java/ject/componote/domain/component/dao/ComponentQueryDsl.java
+++ b/src/main/java/ject/componote/domain/component/dao/ComponentQueryDsl.java
@@ -1,0 +1,14 @@
+package ject.componote.domain.component.dao;
+
+import ject.componote.domain.component.domain.ComponentType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface ComponentQueryDsl {
+    Page<ComponentSummaryDao> searchByKeywordWithTypes(final String keyword, final List<ComponentType> types, final Pageable pageable);
+    Page<ComponentSummaryDao> searchByKeyword(final String keyword, final Pageable pageable);
+    Page<ComponentSummaryDao> searchWithBookmark(final Long memberId, final String keyword, final Pageable pageable);
+    Page<ComponentSummaryDao> searchWithBookmarkAndTypes(final Long memberId, final String keyword, final List<ComponentType> types, final Pageable pageable);
+}

--- a/src/main/java/ject/componote/domain/component/dao/ComponentQueryDslImpl.java
+++ b/src/main/java/ject/componote/domain/component/dao/ComponentQueryDslImpl.java
@@ -1,0 +1,91 @@
+package ject.componote.domain.component.dao;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import ject.componote.domain.component.domain.ComponentType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static ject.componote.domain.bookmark.domain.QBookmark.bookmark;
+import static ject.componote.domain.component.domain.QComponent.component;
+import static ject.componote.domain.component.domain.QMixedName.mixedName;
+import static ject.componote.global.util.RepositoryUtils.eqExpression;
+import static ject.componote.global.util.RepositoryUtils.toPage;
+
+@RequiredArgsConstructor
+public class ComponentQueryDslImpl implements ComponentQueryDsl {
+    private final QComponentDaoFactory componentDaoFactory;
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ComponentSummaryDao> searchByKeyword(final String keyword, final Pageable pageable) {
+        return search(null, keyword, null, pageable, false);
+    }
+
+    @Override
+    public Page<ComponentSummaryDao> searchByKeywordWithTypes(final String keyword, final List<ComponentType> types, final Pageable pageable) {
+        return search(null, keyword, types, pageable, false);
+    }
+
+    @Override
+    public Page<ComponentSummaryDao> searchWithBookmark(final Long memberId, final String keyword, final Pageable pageable) {
+        return search(memberId, keyword, null, pageable, true);
+    }
+
+    @Override
+    public Page<ComponentSummaryDao> searchWithBookmarkAndTypes(final Long memberId, final String keyword, final List<ComponentType> types, final Pageable pageable) {
+        return search(memberId, keyword, types, pageable, true);
+    }
+
+    public Page<ComponentSummaryDao> search(final Long memberId,
+                                            final String keyword,
+                                            final List<ComponentType> types,
+                                            final Pageable pageable,
+                                            final boolean withBookmark) {
+        final JPAQuery<Long> countQuery = createCountQuery(keyword, types);
+        final JPAQuery<ComponentSummaryDao> baseQuery = createBaseQuery(memberId, keyword, types, withBookmark);
+        return toPage(baseQuery, countQuery, component, pageable);
+    }
+
+    private JPAQuery<Long> createCountQuery(final String keyword, final List<ComponentType> types) {
+        return queryFactory.select(component.countDistinct())
+                .from(component)
+                .leftJoin(component.mixedNames, mixedName)
+                .where(createSearchCondition(keyword, types));
+    }
+
+    private JPAQuery<ComponentSummaryDao> createBaseQuery(final Long memberId,
+                                                          final String keyword,
+                                                          final List<ComponentType> types,
+                                                          final boolean withBookmark) {
+        final JPAQuery<ComponentSummaryDao> query = queryFactory.selectDistinct(componentDaoFactory.createForSummary(withBookmark))
+                .from(component)
+                .leftJoin(component.mixedNames, mixedName);
+
+        if (withBookmark && memberId != null) {
+            query.leftJoin(bookmark)
+                    .on(eqExpression(bookmark.componentId, component.id)
+                            .and(eqExpression(bookmark.memberId, memberId)));
+        }
+
+        return query.where(createSearchCondition(keyword, types));
+    }
+
+    private BooleanExpression createSearchCondition(final String keyword, final List<ComponentType> types) {
+        final BooleanExpression keywordCondition = createKeywordCondition(keyword);
+        if (types != null && !types.isEmpty()) {
+            return keywordCondition.and(component.type.in(types));
+        }
+
+        return keywordCondition;
+    }
+
+    private static BooleanExpression createKeywordCondition(final String keyword) {
+        return mixedName.name.contains(keyword)
+                .or(component.summary.title.contains(keyword));
+    }
+}

--- a/src/main/java/ject/componote/domain/component/dao/ComponentRepository.java
+++ b/src/main/java/ject/componote/domain/component/dao/ComponentRepository.java
@@ -1,0 +1,16 @@
+package ject.componote.domain.component.dao;
+
+import ject.componote.domain.component.domain.Component;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ComponentRepository extends JpaRepository<Component, Long>, ComponentQueryDsl {
+    @Query(
+            nativeQuery = true,
+            value = "UPDATE component c SET c.view_count = c.view_count + 1  WHERE c.id =:id"
+    )
+    @Modifying(clearAutomatically = true)
+    void increaseViewCount(@Param("id") final Long id); // 변경 감지 대신 사용할 메서드
+}

--- a/src/main/java/ject/componote/domain/component/dao/ComponentSummaryDao.java
+++ b/src/main/java/ject/componote/domain/component/dao/ComponentSummaryDao.java
@@ -1,0 +1,17 @@
+package ject.componote.domain.component.dao;
+
+import ject.componote.domain.common.model.Count;
+import ject.componote.domain.component.domain.ComponentType;
+import ject.componote.domain.component.domain.summary.ComponentSummary;
+
+public record ComponentSummaryDao(
+        Long id,
+        ComponentSummary summary,
+        ComponentType type,
+        Count bookmarkCount,
+        Count commentCount,
+        Count designReferenceCount,
+        Count viewCount,
+        Boolean isBookmarked
+) {
+}

--- a/src/main/java/ject/componote/domain/component/dao/QComponentDaoFactory.java
+++ b/src/main/java/ject/componote/domain/component/dao/QComponentDaoFactory.java
@@ -1,0 +1,40 @@
+package ject.componote.domain.component.dao;
+
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import org.springframework.stereotype.Component;
+
+import static ject.componote.domain.bookmark.domain.QBookmark.bookmark;
+import static ject.componote.domain.component.domain.QComponent.component;
+
+@Component
+public class QComponentDaoFactory {
+    public ConstructorExpression<ComponentSummaryDao> createForSummary(final boolean withBookmark) {
+        if (withBookmark) {
+            return Projections.constructor(
+                    ComponentSummaryDao.class,
+                    component.id,
+                    component.summary,
+                    component.type,
+                    component.bookmarkCount,
+                    component.commentCount,
+                    component.designReferenceCount,
+                    component.viewCount,
+                    bookmark.isNotNull()
+            );
+        }
+
+        return Projections.constructor(
+                ComponentSummaryDao.class,
+                component.id,
+                component.summary,
+                component.type,
+                component.bookmarkCount,
+                component.commentCount,
+                component.designReferenceCount,
+                component.viewCount,
+                Expressions.asBoolean(false)
+        );
+    }
+}

--- a/src/main/java/ject/componote/domain/component/domain/Component.java
+++ b/src/main/java/ject/componote/domain/component/domain/Component.java
@@ -16,7 +16,7 @@ import jakarta.persistence.OneToMany;
 import ject.componote.domain.common.domain.BaseEntity;
 import ject.componote.domain.common.model.Count;
 import ject.componote.domain.common.model.converter.CountConverter;
-import ject.componote.domain.component.domain.detail.block.ContentBlock;
+import ject.componote.domain.component.domain.block.ContentBlock;
 import ject.componote.domain.component.domain.summary.ComponentSummary;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -56,12 +56,22 @@ public class Component extends BaseEntity {
     @Convert(converter = CountConverter.class)
     private Count commentCount;
 
-    private Component(final ComponentType type, final List<MixedName> mixedNames, final ComponentSummary summary) {
+    @Column(name = "design_reference_count", nullable = false)
+    @Convert(converter = CountConverter.class)
+    private Count designReferenceCount;
+
+    @Column(name = "view_count", nullable = false)
+    @Convert(converter = CountConverter.class)
+    private Count viewCount;
+
+    private Component(final ComponentType type, final List<String> mixedNames, final ComponentSummary summary, final List<ContentBlock> contentBlocks) {
         this.type = type;
         this.mixedNames.addAll(mixedNames);
         this.summary = summary;
         this.bookmarkCount = Count.create();
         this.commentCount = Count.create();
+        this.designReferenceCount = Count.create();
+        this.viewCount = Count.create();
     }
 
     public static Component of(final ComponentType type, final List<MixedName> mixedNames, final ComponentSummary summary) {

--- a/src/main/java/ject/componote/domain/component/domain/ComponentDesign.java
+++ b/src/main/java/ject/componote/domain/component/domain/ComponentDesign.java
@@ -1,0 +1,36 @@
+package ject.componote.domain.component.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import ject.componote.domain.design.domain.Design;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class ComponentDesign {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(name = "component_id", nullable = false)
+    private Long componentId;
+
+    @Column(name = "design_id", nullable = false)
+    private Long designId;
+
+    private ComponentDesign(final Long componentId, final Long designId) {
+        this.componentId = componentId;
+        this.designId = designId;
+    }
+
+    public static ComponentDesign from(final Component component, final Design design) {
+        return new ComponentDesign(component.getId(), design.getId());
+    }
+}

--- a/src/main/java/ject/componote/domain/component/domain/block/BlockType.java
+++ b/src/main/java/ject/componote/domain/component/domain/block/BlockType.java
@@ -1,0 +1,5 @@
+package ject.componote.domain.component.domain.block;
+
+public enum BlockType {
+    INTRODUCTION, DESCRIPTION, USE_CASE, REFERENCE;
+}

--- a/src/main/java/ject/componote/domain/component/domain/block/ContentBlock.java
+++ b/src/main/java/ject/componote/domain/component/domain/block/ContentBlock.java
@@ -1,4 +1,4 @@
-package ject.componote.domain.component.domain.detail.block;
+package ject.componote.domain.component.domain.block;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -9,7 +9,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
-import ject.componote.domain.component.domain.detail.DetailType;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,13 +26,15 @@ public abstract class ContentBlock {
 
     @Column(name = "type", nullable = false)
     @Enumerated(EnumType.STRING)
-    private DetailType type;
+    private BlockType type;
 
     @Column(name = "orders", nullable = false)
     private Integer order;
 
-    public ContentBlock(final DetailType type, final Integer order) {
+    public ContentBlock(final BlockType type, final Integer order) {
         this.type = type;
         this.order = order;
     }
+
+    public abstract String getValue();
 }

--- a/src/main/java/ject/componote/domain/component/domain/block/detail/ImageBlock.java
+++ b/src/main/java/ject/componote/domain/component/domain/block/detail/ImageBlock.java
@@ -3,10 +3,10 @@ package ject.componote.domain.component.domain.block.detail;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import ject.componote.domain.common.model.BaseImage;
-import ject.componote.domain.common.model.converter.BaseImageConverter;
 import ject.componote.domain.component.domain.block.BlockType;
 import ject.componote.domain.component.domain.block.ContentBlock;
+import ject.componote.domain.component.model.ComponentImage;
+import ject.componote.domain.component.model.converter.ComponentImageConverter;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,16 +17,21 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString
 public class ImageBlock extends ContentBlock {
-    @Convert(converter = BaseImageConverter.class)
+    @Convert(converter = ComponentImageConverter.class)
     @Column(name = "image", nullable = false)
-    private BaseImage image;
+    private ComponentImage image;
 
-    private ImageBlock(final BlockType type, final BaseImage image, final Integer order) {
+    private ImageBlock(final BlockType type, final ComponentImage image, final Integer order) {
         super(type, order);
         this.image = image;
     }
 
-    public static ImageBlock of(final BlockType type, final BaseImage image, final Integer order) {
+    public static ImageBlock of(final BlockType type, final ComponentImage image, final Integer order) {
         return new ImageBlock(type, image, order);
+    }
+
+    @Override
+    public String getValue() {
+        return image.getImage().toUrl();
     }
 }

--- a/src/main/java/ject/componote/domain/component/domain/block/detail/ImageBlock.java
+++ b/src/main/java/ject/componote/domain/component/domain/block/detail/ImageBlock.java
@@ -32,6 +32,6 @@ public class ImageBlock extends ContentBlock {
 
     @Override
     public String getValue() {
-        return image.getImage().toUrl();
+        return image.toUrl();
     }
 }

--- a/src/main/java/ject/componote/domain/component/domain/block/detail/TextBlock.java
+++ b/src/main/java/ject/componote/domain/component/domain/block/detail/TextBlock.java
@@ -29,4 +29,9 @@ public class TextBlock extends ContentBlock {
     public static TextBlock of(final BlockType type, final ComponentContent content, final Integer order) {
         return new TextBlock(type, content, order);
     }
+
+    @Override
+    public String getValue() {
+        return content.getValue();
+    }
 }

--- a/src/main/java/ject/componote/domain/component/domain/detail/DetailType.java
+++ b/src/main/java/ject/componote/domain/component/domain/detail/DetailType.java
@@ -1,5 +1,0 @@
-package ject.componote.domain.component.domain.detail;
-
-public enum DetailType {
-    INTRODUCTION, DESCRIPTION, USE_CASE, REFERENCE;
-}

--- a/src/main/java/ject/componote/domain/component/domain/summary/ComponentSummary.java
+++ b/src/main/java/ject/componote/domain/component/domain/summary/ComponentSummary.java
@@ -6,11 +6,13 @@ import jakarta.persistence.Embeddable;
 import ject.componote.domain.component.model.ComponentThumbnail;
 import ject.componote.domain.component.model.converter.ComponentThumbnailConverter;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Embeddable
+@EqualsAndHashCode
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString

--- a/src/main/java/ject/componote/domain/component/domain/summary/ComponentSummary.java
+++ b/src/main/java/ject/componote/domain/component/domain/summary/ComponentSummary.java
@@ -3,8 +3,8 @@ package ject.componote.domain.component.domain.summary;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
-import ject.componote.domain.common.model.Image;
-import ject.componote.domain.common.model.converter.ImageConverter;
+import ject.componote.domain.component.model.ComponentThumbnail;
+import ject.componote.domain.component.model.converter.ComponentThumbnailConverter;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,18 +18,18 @@ public class ComponentSummary {
     @Column(name = "title", nullable = false)
     private String title;
 
-    @Column(name = "summary", nullable = false)
-    private String summary;
+    @Column(name = "description", nullable = false)
+    private String description;
 
-    @Convert(converter = ImageConverter.class)
+    @Convert(converter = ComponentThumbnailConverter.class)
     @Column(name = "thumbnail", nullable = false)
-    private Image thumbnail;
+    private ComponentThumbnail thumbnail;
 
-    private ComponentSummary(final String title, final String summary, final Image thumbnail) {
+    private ComponentSummary(final String title, final String description, final ComponentThumbnail thumbnail) {
         validateTitle(title);
-        validateSummary(summary);
+        validateDescription(description);
         this.title = title;
-        this.summary = summary;
+        this.description = description;
         this.thumbnail = thumbnail;
     }
 
@@ -37,11 +37,11 @@ public class ComponentSummary {
 
     }
 
-    private void validateSummary(final String summary) {
+    private void validateDescription(final String description) {
 
     }
 
-    public static ComponentSummary of(final String title, final String summary, final Image thumbnail) {
-        return new ComponentSummary(title, summary, thumbnail);
+    public static ComponentSummary of(final String title, final String description, final String thumbnailObjectKey) {
+        return new ComponentSummary(title, description, ComponentThumbnail.from(thumbnailObjectKey));
     }
 }

--- a/src/main/java/ject/componote/domain/component/dto/find/event/ComponentViewCountIncreaseEvent.java
+++ b/src/main/java/ject/componote/domain/component/dto/find/event/ComponentViewCountIncreaseEvent.java
@@ -1,0 +1,9 @@
+package ject.componote.domain.component.dto.find.event;
+
+import ject.componote.domain.component.domain.Component;
+
+public record ComponentViewCountIncreaseEvent(Long componentId) {
+    public static ComponentViewCountIncreaseEvent from(final Component component) {
+        return new ComponentViewCountIncreaseEvent(component.getId());
+    }
+}

--- a/src/main/java/ject/componote/domain/component/dto/find/request/ComponentSearchRequest.java
+++ b/src/main/java/ject/componote/domain/component/dto/find/request/ComponentSearchRequest.java
@@ -1,0 +1,12 @@
+package ject.componote.domain.component.dto.find.request;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import ject.componote.domain.component.domain.ComponentType;
+
+import java.util.List;
+
+public record ComponentSearchRequest(
+        @NotBlank String keyword,
+        @Nullable List<ComponentType> types) {
+}

--- a/src/main/java/ject/componote/domain/component/dto/find/response/ComponentBlockResponse.java
+++ b/src/main/java/ject/componote/domain/component/dto/find/response/ComponentBlockResponse.java
@@ -1,0 +1,12 @@
+package ject.componote.domain.component.dto.find.response;
+
+import ject.componote.domain.component.domain.block.ContentBlock;
+
+public record ComponentBlockResponse(Integer order, String content) {
+    public static ComponentBlockResponse from(final ContentBlock contentBlock) {
+        return new ComponentBlockResponse(
+                contentBlock.getOrder(),
+                contentBlock.getValue()
+        );
+    }
+}

--- a/src/main/java/ject/componote/domain/component/dto/find/response/ComponentDetailResponse.java
+++ b/src/main/java/ject/componote/domain/component/dto/find/response/ComponentDetailResponse.java
@@ -1,0 +1,20 @@
+package ject.componote.domain.component.dto.find.response;
+
+import ject.componote.domain.component.domain.block.BlockType;
+
+import java.util.List;
+import java.util.Map;
+
+public record ComponentDetailResponse(
+        String title,
+        List<String> mixedNames,
+        String description,
+        Long commentCount,
+        Long bookmarkCount,
+        Long designReferenceCount,
+        String thumbnailUrl,
+        Map<BlockType, List<ComponentBlockResponse>> blocks,
+        Boolean isBookmarked
+) {
+
+}

--- a/src/main/java/ject/componote/domain/component/dto/find/response/ComponentSummaryResponse.java
+++ b/src/main/java/ject/componote/domain/component/dto/find/response/ComponentSummaryResponse.java
@@ -17,7 +17,7 @@ public record ComponentSummaryResponse(
         final ComponentSummary summary = dao.summary();
         return new ComponentSummaryResponse(
                 dao.id(),
-                summary.getThumbnail().getImage().toUrl(),
+                summary.getThumbnail().toUrl(),
                 summary.getTitle(),
                 summary.getDescription(),
                 dao.type().name(),

--- a/src/main/java/ject/componote/domain/component/dto/find/response/ComponentSummaryResponse.java
+++ b/src/main/java/ject/componote/domain/component/dto/find/response/ComponentSummaryResponse.java
@@ -1,0 +1,30 @@
+package ject.componote.domain.component.dto.find.response;
+
+import ject.componote.domain.component.dao.ComponentSummaryDao;
+import ject.componote.domain.component.domain.summary.ComponentSummary;
+
+public record ComponentSummaryResponse(
+        Long id,
+        String thumbnailUrl,
+        String title,
+        String description,
+        String type,
+        Long bookmarkCount,
+        Long commentCount,
+        Long designReferenceCount,
+        Boolean isBookmarked) {
+    public static ComponentSummaryResponse from(final ComponentSummaryDao dao) {
+        final ComponentSummary summary = dao.summary();
+        return new ComponentSummaryResponse(
+                dao.id(),
+                summary.getThumbnail().getImage().toUrl(),
+                summary.getTitle(),
+                summary.getDescription(),
+                dao.type().name(),
+                dao.bookmarkCount().getValue(),
+                dao.commentCount().getValue(),
+                dao.designReferenceCount().getValue(),
+                dao.isBookmarked()
+        );
+    }
+}

--- a/src/main/java/ject/componote/domain/component/error/ComponentException.java
+++ b/src/main/java/ject/componote/domain/component/error/ComponentException.java
@@ -1,4 +1,10 @@
 package ject.componote.domain.component.error;
 
-public class ComponentException {
+import ject.componote.global.error.ComponoteException;
+import org.springframework.http.HttpStatus;
+
+public class ComponentException extends ComponoteException {
+    public ComponentException(final String message, final HttpStatus status) {
+        super(message, status);
+    }
 }

--- a/src/main/java/ject/componote/domain/component/error/InvalidCommentSearchStrategyException.java
+++ b/src/main/java/ject/componote/domain/component/error/InvalidCommentSearchStrategyException.java
@@ -1,0 +1,9 @@
+package ject.componote.domain.component.error;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidCommentSearchStrategyException extends ComponentException {
+    public InvalidCommentSearchStrategyException() {
+        super("컴포넌트 검색에 실패했습니다. 요청 Body를 확인해주세요.", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/ject/componote/domain/component/error/InvalidComponentImageExtensionException.java
+++ b/src/main/java/ject/componote/domain/component/error/InvalidComponentImageExtensionException.java
@@ -1,0 +1,9 @@
+package ject.componote.domain.component.error;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidComponentImageExtensionException extends ComponentException {
+    public InvalidComponentImageExtensionException(final String extension) {
+        super("확장자가 올바르지 않습니다. 입력된 확장자: " + extension, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/ject/componote/domain/component/error/InvalidComponentThumbnailExtensionException.java
+++ b/src/main/java/ject/componote/domain/component/error/InvalidComponentThumbnailExtensionException.java
@@ -1,0 +1,9 @@
+package ject.componote.domain.component.error;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidComponentThumbnailExtensionException extends ComponentException {
+    public InvalidComponentThumbnailExtensionException(final String extension) {
+        super("확장자가 올바르지 않습니다. 입력된 확장자: " + extension, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/ject/componote/domain/component/error/NotFoundComponentException.java
+++ b/src/main/java/ject/componote/domain/component/error/NotFoundComponentException.java
@@ -1,0 +1,9 @@
+package ject.componote.domain.component.error;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundComponentException extends ComponentException {
+    public NotFoundComponentException(final Long componentId) {
+        super("컴포넌트를 찾을 수 없습니다. 컴포넌트 ID: " + componentId, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/ject/componote/domain/component/error/NotFoundComponentImageException.java
+++ b/src/main/java/ject/componote/domain/component/error/NotFoundComponentImageException.java
@@ -1,0 +1,9 @@
+package ject.componote.domain.component.error;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundComponentImageException extends ComponentException {
+    public NotFoundComponentImageException() {
+        super("이미지 objectKey를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/ject/componote/domain/component/error/NotFoundComponentThumbnailException.java
+++ b/src/main/java/ject/componote/domain/component/error/NotFoundComponentThumbnailException.java
@@ -1,0 +1,9 @@
+package ject.componote.domain.component.error;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundComponentThumbnailException extends ComponentException {
+    public NotFoundComponentThumbnailException() {
+        super("이미지 objectKey를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/ject/componote/domain/component/model/ComponentImage.java
+++ b/src/main/java/ject/componote/domain/component/model/ComponentImage.java
@@ -1,0 +1,35 @@
+package ject.componote.domain.component.model;
+
+import ject.componote.domain.common.model.BaseImage;
+import ject.componote.domain.component.error.InvalidComponentImageExtensionException;
+import ject.componote.domain.component.error.NotFoundComponentImageException;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@EqualsAndHashCode
+@Getter
+public class ComponentImage {
+    private static final List<String> ALLOWED_IMAGE_EXTENSIONS = List.of("png");
+
+    private final BaseImage image;
+
+    private ComponentImage(final BaseImage image) {
+        this.image = image;
+    }
+
+    public static ComponentImage from(final String objectKey) {
+        if (objectKey == null || objectKey.isEmpty()) {
+            throw new NotFoundComponentImageException();
+        }
+
+        final String extension = StringUtils.getFilenameExtension(objectKey);
+        if (!ALLOWED_IMAGE_EXTENSIONS.contains(extension)) {
+            throw new InvalidComponentImageExtensionException(extension);
+        }
+
+        return new ComponentImage(BaseImage.from(objectKey));
+    }
+}

--- a/src/main/java/ject/componote/domain/component/model/ComponentImage.java
+++ b/src/main/java/ject/componote/domain/component/model/ComponentImage.java
@@ -7,12 +7,14 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.springframework.util.StringUtils;
 
+import java.util.Arrays;
 import java.util.List;
 
 @EqualsAndHashCode
 @Getter
 public class ComponentImage {
-    private static final List<String> ALLOWED_IMAGE_EXTENSIONS = List.of("png");
+    // Arrays.asList 로 만든 List: contains(null) 시 NPE 발생하지 않고 false 리턴
+    private static final List<String> ALLOWED_IMAGE_EXTENSIONS = Arrays.asList("png");
 
     private final BaseImage image;
 

--- a/src/main/java/ject/componote/domain/component/model/ComponentImage.java
+++ b/src/main/java/ject/componote/domain/component/model/ComponentImage.java
@@ -1,25 +1,23 @@
 package ject.componote.domain.component.model;
 
-import ject.componote.domain.common.model.BaseImage;
+import ject.componote.domain.common.model.AbstractImage;
 import ject.componote.domain.component.error.InvalidComponentImageExtensionException;
 import ject.componote.domain.component.error.NotFoundComponentImageException;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.ToString;
 import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
 
-@EqualsAndHashCode
-@Getter
-public class ComponentImage {
+@EqualsAndHashCode(callSuper = true)
+@ToString
+public class ComponentImage extends AbstractImage {
     // Arrays.asList 로 만든 List: contains(null) 시 NPE 발생하지 않고 false 리턴
     private static final List<String> ALLOWED_IMAGE_EXTENSIONS = Arrays.asList("png");
 
-    private final BaseImage image;
-
-    private ComponentImage(final BaseImage image) {
-        this.image = image;
+    public ComponentImage(final String objectKey) {
+        super(objectKey);
     }
 
     public static ComponentImage from(final String objectKey) {
@@ -32,6 +30,6 @@ public class ComponentImage {
             throw new InvalidComponentImageExtensionException(extension);
         }
 
-        return new ComponentImage(BaseImage.from(objectKey));
+        return new ComponentImage(objectKey);
     }
 }

--- a/src/main/java/ject/componote/domain/component/model/ComponentThumbnail.java
+++ b/src/main/java/ject/componote/domain/component/model/ComponentThumbnail.java
@@ -1,0 +1,36 @@
+package ject.componote.domain.component.model;
+
+import ject.componote.domain.common.model.BaseImage;
+import ject.componote.domain.component.error.InvalidComponentThumbnailExtensionException;
+import ject.componote.domain.component.error.NotFoundComponentThumbnailException;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+@EqualsAndHashCode
+@Getter
+public class ComponentThumbnail {
+    private static final List<String> ALLOWED_IMAGE_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png");
+
+    private final BaseImage image;
+
+    private ComponentThumbnail(final BaseImage image) {
+        this.image = image;
+    }
+
+    public static ComponentThumbnail from(final String objectKey) {
+        if (objectKey == null || objectKey.isEmpty()) {
+            throw new NotFoundComponentThumbnailException();
+        }
+
+        final String extension = StringUtils.getFilenameExtension(objectKey);
+        if (!ALLOWED_IMAGE_EXTENSIONS.contains(extension)) {
+            throw new InvalidComponentThumbnailExtensionException(extension);
+        }
+
+        return new ComponentThumbnail(BaseImage.from(objectKey));
+    }
+}

--- a/src/main/java/ject/componote/domain/component/model/ComponentThumbnail.java
+++ b/src/main/java/ject/componote/domain/component/model/ComponentThumbnail.java
@@ -1,24 +1,22 @@
 package ject.componote.domain.component.model;
 
-import ject.componote.domain.common.model.BaseImage;
+import ject.componote.domain.common.model.AbstractImage;
 import ject.componote.domain.component.error.InvalidComponentThumbnailExtensionException;
 import ject.componote.domain.component.error.NotFoundComponentThumbnailException;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.ToString;
 import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
 
-@EqualsAndHashCode
-@Getter
-public class ComponentThumbnail {
+@EqualsAndHashCode(callSuper = true)
+@ToString
+public class ComponentThumbnail extends AbstractImage {
     private static final List<String> ALLOWED_IMAGE_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png");
 
-    private final BaseImage image;
-
-    private ComponentThumbnail(final BaseImage image) {
-        this.image = image;
+    public ComponentThumbnail(final String objectKey) {
+        super(objectKey);
     }
 
     public static ComponentThumbnail from(final String objectKey) {
@@ -31,6 +29,6 @@ public class ComponentThumbnail {
             throw new InvalidComponentThumbnailExtensionException(extension);
         }
 
-        return new ComponentThumbnail(BaseImage.from(objectKey));
+        return new ComponentThumbnail(objectKey);
     }
 }

--- a/src/main/java/ject/componote/domain/component/model/converter/ComponentImageConverter.java
+++ b/src/main/java/ject/componote/domain/component/model/converter/ComponentImageConverter.java
@@ -8,7 +8,7 @@ import ject.componote.domain.component.model.ComponentImage;
 public class ComponentImageConverter implements AttributeConverter<ComponentImage, String> {
     @Override
     public String convertToDatabaseColumn(final ComponentImage attribute) {
-        return attribute.getImage().getObjectKey();
+        return attribute.getObjectKey();
     }
 
     @Override

--- a/src/main/java/ject/componote/domain/component/model/converter/ComponentImageConverter.java
+++ b/src/main/java/ject/componote/domain/component/model/converter/ComponentImageConverter.java
@@ -1,0 +1,18 @@
+package ject.componote.domain.component.model.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import ject.componote.domain.component.model.ComponentImage;
+
+@Converter
+public class ComponentImageConverter implements AttributeConverter<ComponentImage, String> {
+    @Override
+    public String convertToDatabaseColumn(final ComponentImage attribute) {
+        return attribute.getImage().getObjectKey();
+    }
+
+    @Override
+    public ComponentImage convertToEntityAttribute(final String dbData) {
+        return ComponentImage.from(dbData);
+    }
+}

--- a/src/main/java/ject/componote/domain/component/model/converter/ComponentThumbnailConverter.java
+++ b/src/main/java/ject/componote/domain/component/model/converter/ComponentThumbnailConverter.java
@@ -8,7 +8,7 @@ import ject.componote.domain.component.model.ComponentThumbnail;
 public class ComponentThumbnailConverter implements AttributeConverter<ComponentThumbnail, String> {
     @Override
     public String convertToDatabaseColumn(final ComponentThumbnail attribute) {
-        return attribute.getImage().getObjectKey();
+        return attribute.getObjectKey();
     }
 
     @Override

--- a/src/main/java/ject/componote/domain/component/model/converter/ComponentThumbnailConverter.java
+++ b/src/main/java/ject/componote/domain/component/model/converter/ComponentThumbnailConverter.java
@@ -1,0 +1,18 @@
+package ject.componote.domain.component.model.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import ject.componote.domain.component.model.ComponentThumbnail;
+
+@Converter
+public class ComponentThumbnailConverter implements AttributeConverter<ComponentThumbnail, String> {
+    @Override
+    public String convertToDatabaseColumn(final ComponentThumbnail attribute) {
+        return attribute.getImage().getObjectKey();
+    }
+
+    @Override
+    public ComponentThumbnail convertToEntityAttribute(final String dbData) {
+        return ComponentThumbnail.from(dbData);
+    }
+}

--- a/src/main/java/ject/componote/domain/component/util/ComponentMapper.java
+++ b/src/main/java/ject/componote/domain/component/util/ComponentMapper.java
@@ -1,0 +1,47 @@
+package ject.componote.domain.component.util;
+
+import ject.componote.domain.component.domain.Component;
+import ject.componote.domain.component.domain.MixedName;
+import ject.componote.domain.component.domain.block.BlockType;
+import ject.componote.domain.component.domain.block.ContentBlock;
+import ject.componote.domain.component.domain.summary.ComponentSummary;
+import ject.componote.domain.component.dto.find.response.ComponentBlockResponse;
+import ject.componote.domain.component.dto.find.response.ComponentDetailResponse;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@org.springframework.stereotype.Component
+public class ComponentMapper {
+    public ComponentDetailResponse mapFrom(final Component component, final Boolean isBookmarked) {
+        final ComponentSummary summary = component.getSummary();
+        return new ComponentDetailResponse(
+                summary.getTitle(),
+                parseMixedNames(component),
+                summary.getDescription(),
+                component.getCommentCount().getValue(),
+                component.getBookmarkCount().getValue(),
+                component.getDesignReferenceCount().getValue(),
+                summary.getThumbnail().getImage().toUrl(),
+                parseBlocks(component),
+                isBookmarked
+        );
+    }
+
+    private List<String> parseMixedNames(final Component component) {
+        return component.getMixedNames()
+                .stream()
+                .map(MixedName::getName)
+                .toList();
+    }
+
+    private Map<BlockType, List<ComponentBlockResponse>> parseBlocks(final Component component) {
+        final List<ContentBlock> contentBlocks = component.getContentBlocks();
+        return contentBlocks.stream()
+                .collect(Collectors.groupingBy(
+                        ContentBlock::getType,
+                        Collectors.mapping(ComponentBlockResponse::from, Collectors.toList()))
+                );
+    }
+}

--- a/src/main/java/ject/componote/domain/component/util/ComponentMapper.java
+++ b/src/main/java/ject/componote/domain/component/util/ComponentMapper.java
@@ -23,7 +23,7 @@ public class ComponentMapper {
                 component.getCommentCount().getValue(),
                 component.getBookmarkCount().getValue(),
                 component.getDesignReferenceCount().getValue(),
-                summary.getThumbnail().getImage().toUrl(),
+                summary.getThumbnail().toUrl(),
                 parseBlocks(component),
                 isBookmarked
         );

--- a/src/main/java/ject/componote/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/ject/componote/global/error/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import jakarta.servlet.ServletException;
 import jakarta.validation.ConstraintViolationException;
 import ject.componote.infra.error.InfraException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -36,6 +37,12 @@ public class GlobalExceptionHandler {
         log.error("SQL 예외 발생. ", exception);
         return ResponseEntity.status(INTERNAL_SERVER_ERROR)
                 .body(ErrorResponse.of(INTERNAL_SERVER_ERROR, "SQL 오류입니다."));
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<ErrorResponse> handleDataAccessException(final DataAccessException exception) {
+        return ResponseEntity.status(BAD_REQUEST)
+                .body(ErrorResponse.of(BAD_REQUEST, exception.getLocalizedMessage()));
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)

--- a/src/main/java/ject/componote/infra/file/application/FileClient.java
+++ b/src/main/java/ject/componote/infra/file/application/FileClient.java
@@ -23,10 +23,10 @@ public class FileClient {
     private final TimeoutDecorator timeoutDecorator;
     private final WebClient webClient;
 
-    public FileClient(@Value("${file.max-retry}") final int maxRetry,
-                      @Value("${file.timeout}") final int timeout,
-                      @Value("${file.client.move.method}") final HttpMethod method,
-                      @Value("${file.client.move.uri}") final String uri,
+    public FileClient(@Value("${storage.max-retry}") final int maxRetry,
+                      @Value("${storage.timeout}") final int timeout,
+                      @Value("${storage.client.move.method}") final HttpMethod method,
+                      @Value("${storage.client.move.uri}") final String uri,
                       final TimeoutDecorator timeoutDecorator,
                       final WebClient webClient) {
         this.maxRetry = maxRetry;

--- a/src/main/java/ject/componote/infra/file/application/FileClient.java
+++ b/src/main/java/ject/componote/infra/file/application/FileClient.java
@@ -1,8 +1,8 @@
 package ject.componote.infra.file.application;
 
-import ject.componote.global.error.ErrorResponse;
 import ject.componote.infra.file.dto.move.request.MoveRequest;
 import ject.componote.infra.file.error.FileClientException;
+import ject.componote.infra.file.error.FileServerErrorResponse;
 import ject.componote.infra.util.TimeoutDecorator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -59,13 +59,13 @@ public class FileClient {
     }
 
     private Mono<? extends Throwable> handle5xxError(final ClientResponse clientResponse) {
-        return clientResponse.bodyToMono(ErrorResponse.class)
-                .map(ErrorResponse::getMessage)
+        return clientResponse.bodyToMono(FileServerErrorResponse.class)
+                .map(FileServerErrorResponse::getMessage)
                 .map(IllegalStateException::new);
     }
 
     private Mono<? extends Throwable> handle4xxError(final ClientResponse clientResponse) {
-        return clientResponse.bodyToMono(ErrorResponse.class)
+        return clientResponse.bodyToMono(FileServerErrorResponse.class)
                 .map(FileClientException::new);
     }
 

--- a/src/main/java/ject/componote/infra/file/application/FileService.java
+++ b/src/main/java/ject/componote/infra/file/application/FileService.java
@@ -1,6 +1,6 @@
 package ject.componote.infra.file.application;
 
-import ject.componote.domain.common.model.BaseImage;
+import ject.componote.domain.common.model.AbstractImage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -12,7 +12,7 @@ import reactor.core.scheduler.Schedulers;
 public class FileService {
     private final FileClient fileClient;
 
-    public void moveImage(final BaseImage image) {
+    public void moveImage(final AbstractImage image) {
         if (image.isEmpty()) {
             log.warn("No image to move");
             return;

--- a/src/main/java/ject/componote/infra/file/error/FileClientException.java
+++ b/src/main/java/ject/componote/infra/file/error/FileClientException.java
@@ -1,11 +1,10 @@
 package ject.componote.infra.file.error;
 
-import ject.componote.global.error.ErrorResponse;
 import ject.componote.infra.error.InfraException;
 import org.springframework.http.HttpStatus;
 
 public class FileClientException extends InfraException {
-    public FileClientException(final ErrorResponse errorResponse) {
-        super(errorResponse.getMessage(), HttpStatus.valueOf(errorResponse.getStatus()));
+    public FileClientException(final FileServerErrorResponse response) {
+        super(response.getMessage(), HttpStatus.valueOf(response.getStatus()));
     }
 }

--- a/src/main/java/ject/componote/infra/file/error/FileServerErrorResponse.java
+++ b/src/main/java/ject/componote/infra/file/error/FileServerErrorResponse.java
@@ -1,0 +1,24 @@
+package ject.componote.infra.file.error;
+
+import ject.componote.global.error.ErrorResponse;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class FileServerErrorResponse {
+    private int status;
+    private String message;
+
+    public static ErrorResponse of(final HttpStatus status, final String message) {
+        return new ErrorResponse(status.value(), message);
+    }
+
+    public static ErrorResponse of(final HttpStatus status, final Exception exception) {
+        return new ErrorResponse(status.value(), exception.getMessage());
+    }
+}

--- a/src/test/java/ject/componote/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/ject/componote/domain/auth/application/AuthServiceTest.java
@@ -52,7 +52,7 @@ class AuthServiceTest {
     Long socialAccountId = 1L;
     Member member = KIM.생성(socialAccountId);
     ProfileImage profileImage = member.getProfileImage();
-    String profileImageObjectKey = profileImage.getImage().getObjectKey();
+    String profileImageObjectKey = profileImage.getObjectKey();
 
     @DisplayName("회원 가입")
     @Test
@@ -74,7 +74,7 @@ class AuthServiceTest {
         doReturn(member).when(memberRepository)
                 .save(any());
         doNothing().when(fileService)
-                .moveImage(profileImage.getImage());
+                .moveImage(profileImage);
         final MemberSignupResponse actual = authService.signup(request);
 
         // then
@@ -142,7 +142,7 @@ class AuthServiceTest {
         doReturn(member).when(memberRepository)
                 .save(any());
         doThrow(FileClientException.class).when(fileService)
-                .moveImage(profileImage.getImage());
+                .moveImage(profileImage);
 
         // then
         assertThatThrownBy(() -> authService.signup(request))

--- a/src/test/java/ject/componote/domain/auth/application/MemberServiceTest.java
+++ b/src/test/java/ject/componote/domain/auth/application/MemberServiceTest.java
@@ -77,7 +77,7 @@ class MemberServiceTest {
         doReturn(Optional.of(member)).when(memberRepository)
                 .findById(memberId);
         doNothing().when(fileService)
-                .moveImage(newProfileImage.getImage());
+                .moveImage(newProfileImage);
         memberService.updateProfileImage(authPrincipal, request);
 
         // then

--- a/src/test/java/ject/componote/domain/comment/application/CommentCreationStrategyTest.java
+++ b/src/test/java/ject/componote/domain/comment/application/CommentCreationStrategyTest.java
@@ -24,7 +24,7 @@ class CommentCreationStrategyTest {
 
         // then
         assertThat(createdComment.getContent().getValue()).isEqualTo(createRequest.content());
-        assertThat(createdComment.getImage().getImage().getObjectKey()).isEqualTo(createRequest.imageObjectKey());
+        assertThat(createdComment.getImage().getObjectKey()).isEqualTo(createRequest.imageObjectKey());
         assertThat(createdComment.getMemberId()).isEqualTo(memberId);
         assertThat(createdComment.getComponentId()).isEqualTo(createRequest.componentId());
         assertThat(createdComment.getParentId()).isEqualTo(createRequest.parentId());

--- a/src/test/java/ject/componote/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/ject/componote/domain/comment/application/CommentServiceTest.java
@@ -93,7 +93,7 @@ class CommentServiceTest {
         doReturn(comment).when(commentRepository)
                 .save(any());
         doNothing().when(fileService)
-                .moveImage(comment.getImage().getImage());
+                .moveImage(comment.getImage());
         final CommentCreateResponse actual = commentService.create(authPrincipal, createRequest);
 
         // then
@@ -205,7 +205,7 @@ class CommentServiceTest {
         assertDoesNotThrow(
                 () -> commentService.update(authPrincipal, commentId, request)
         );
-        assertThat(comment.getImage().getImage().getObjectKey()).isEqualTo(newObjectKey);
+        assertThat(comment.getImage().getObjectKey()).isEqualTo(newObjectKey);
     }
 
     @ParameterizedTest
@@ -216,7 +216,7 @@ class CommentServiceTest {
         final Long memberId = authPrincipal.id();
         final Comment comment = fixture.생성();
         final Long commentId = comment.getId();
-        final String objectKey = comment.getImage().getImage().getObjectKey();
+        final String objectKey = comment.getImage().getObjectKey();
         final String newContent = "수정된 내용";
         final CommentUpdateRequest request = new CommentUpdateRequest(objectKey, newContent);
 
@@ -251,7 +251,7 @@ class CommentServiceTest {
         assertDoesNotThrow(
                 () -> commentService.update(authPrincipal, commentId, request)
         );
-        assertThat(comment.getImage().getImage().getObjectKey()).isEqualTo(newObjectKey);
+        assertThat(comment.getImage().getObjectKey()).isEqualTo(newObjectKey);
         assertThat(comment.getContent().getValue()).isEqualTo(newContent);
     }
 

--- a/src/test/java/ject/componote/domain/comment/model/CommentImageTest.java
+++ b/src/test/java/ject/componote/domain/comment/model/CommentImageTest.java
@@ -1,7 +1,6 @@
 package ject.componote.domain.comment.model;
 
 import ject.componote.domain.comment.error.InvalidCommentImageExtensionException;
-import ject.componote.domain.common.model.BaseImage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -17,7 +16,7 @@ class CommentImageTest {
         final String objectKey = "";
         final CommentImage commentImage = CommentImage.from(objectKey);
         assertThat(commentImage).isNotNull();
-        assertThat(commentImage.getImage()).isEqualTo(BaseImage.getEmptyInstance());
+        assertThat(commentImage.getObjectKey()).isNull();
     }
 
     @ParameterizedTest

--- a/src/test/java/ject/componote/domain/component/application/ComponentSearchStrategyTest.java
+++ b/src/test/java/ject/componote/domain/component/application/ComponentSearchStrategyTest.java
@@ -1,0 +1,133 @@
+package ject.componote.domain.component.application;
+
+import ject.componote.domain.auth.model.AuthPrincipal;
+import ject.componote.domain.component.dao.ComponentRepository;
+import ject.componote.domain.component.dao.ComponentSummaryDao;
+import ject.componote.domain.component.domain.ComponentType;
+import ject.componote.domain.component.dto.find.request.ComponentSearchRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static ject.componote.fixture.MemberFixture.KIM;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ComponentSearchStrategyParameterizedTest {
+    @Mock
+    ComponentRepository componentRepository;
+
+    static Stream<TestInput> provideTestInputs() {
+        final AuthPrincipal authPrincipal = AuthPrincipal.from(KIM.생성(1L));
+        final List<ComponentType> types = List.of(ComponentType.INPUT, ComponentType.DISPLAY);
+        return Stream.of(
+                new TestInput(
+                        "WITH_BOOKMARK_AND_FILTER",
+                        new ComponentSearchRequest("keyword", types),
+                        authPrincipal,
+                        true,
+                        "searchWithBookmarkAndTypes"
+                ),
+                new TestInput(
+                        "WITH_BOOKMARK",
+                        new ComponentSearchRequest("keyword", null),
+                        authPrincipal,
+                        true,
+                        "searchWithBookmark"
+                ),
+                new TestInput(
+                        "WITHOUT_BOOKMARK_AND_FILTER",
+                        new ComponentSearchRequest("keyword", null),
+                        null,
+                        false,
+                        "searchByKeyword"
+                ),
+                new TestInput(
+                        "WITHOUT_BOOKMARK",
+                        new ComponentSearchRequest("keyword", types),
+                        null,
+                        false,
+                        "searchByKeywordWithTypes"
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTestInputs")
+    @DisplayName("요청값에 알맞는 검색 메서드 실행")
+    void testComponentSearchStrategy(final TestInput input) {
+        // given
+        final AuthPrincipal authPrincipal = input.authPrincipal;
+        final String keyword = input.request.keyword();
+        final List<ComponentType> types = input.request.types();
+        final Pageable pageable = Pageable.unpaged();
+        final Page<?> expect = new PageImpl<>(List.of());
+
+        // when
+        switch (input.expectedMethod) {
+            case "searchWithBookmarkAndTypes" -> doReturn(expect).when(componentRepository)
+                    .searchWithBookmarkAndTypes(authPrincipal.id(), keyword, types, pageable);
+            case "searchWithBookmark" -> doReturn(expect).when(componentRepository)
+                    .searchWithBookmark(authPrincipal.id(), keyword, pageable);
+            case "searchByKeywordWithTypes" -> doReturn(expect).when(componentRepository)
+                    .searchByKeywordWithTypes(keyword, types, pageable);
+            case "searchByKeyword" -> doReturn(expect).when(componentRepository)
+                    .searchByKeyword(keyword, pageable);
+            default -> throw new IllegalStateException("Unexpected value: " + input.expectedMethod);
+        }
+
+        final Page<ComponentSummaryDao> actual = ComponentSearchStrategy.searchBy(
+                authPrincipal,
+                componentRepository,
+                input.request,
+                pageable
+        );
+
+        // then
+        assertNotNull(actual);
+
+        // 메서드 호출 여부 검증
+        switch (input.expectedMethod) {
+            case "searchWithBookmarkAndTypes" -> verify(componentRepository)
+                    .searchWithBookmarkAndTypes(authPrincipal.id(), keyword, types, pageable);
+            case "searchWithBookmark" -> verify(componentRepository)
+                    .searchWithBookmark(authPrincipal.id(), keyword, pageable);
+            case "searchByKeywordWithTypes" -> verify(componentRepository)
+                    .searchByKeywordWithTypes(keyword, types, pageable);
+            case "searchByKeyword" -> verify(componentRepository)
+                    .searchByKeyword(keyword, pageable);
+            default -> throw new IllegalStateException("Unexpected value: " + input.expectedMethod);
+        }
+    }
+
+    static class TestInput {
+        String strategyName;
+        ComponentSearchRequest request;
+        AuthPrincipal authPrincipal;
+        boolean isLoggedIn;
+        String expectedMethod;
+
+        TestInput(final String strategyName,
+                  final ComponentSearchRequest request,
+                  final AuthPrincipal authPrincipal,
+                  final boolean isLoggedIn,
+                  final String expectedMethod) {
+            this.strategyName = strategyName;
+            this.request = request;
+            this.authPrincipal = authPrincipal;
+            this.isLoggedIn = isLoggedIn;
+            this.expectedMethod = expectedMethod;
+        }
+    }
+}

--- a/src/test/java/ject/componote/domain/component/application/ComponentServiceTest.java
+++ b/src/test/java/ject/componote/domain/component/application/ComponentServiceTest.java
@@ -1,0 +1,210 @@
+package ject.componote.domain.component.application;
+
+import ject.componote.domain.auth.model.AuthPrincipal;
+import ject.componote.domain.bookmark.dao.BookmarkRepository;
+import ject.componote.domain.common.dto.response.PageResponse;
+import ject.componote.domain.component.dao.ComponentRepository;
+import ject.componote.domain.component.dao.ComponentSummaryDao;
+import ject.componote.domain.component.domain.Component;
+import ject.componote.domain.component.domain.ComponentType;
+import ject.componote.domain.component.dto.find.event.ComponentViewCountIncreaseEvent;
+import ject.componote.domain.component.dto.find.request.ComponentSearchRequest;
+import ject.componote.domain.component.dto.find.response.ComponentDetailResponse;
+import ject.componote.domain.component.dto.find.response.ComponentSummaryResponse;
+import ject.componote.domain.component.error.NotFoundComponentException;
+import ject.componote.domain.component.util.ComponentMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static ject.componote.fixture.ComponentFixture.INPUT_COMPONENT;
+import static ject.componote.fixture.MemberFixture.KIM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ComponentServiceTest {
+    @Mock
+    ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    BookmarkRepository bookmarkRepository;
+
+    @Mock
+    ComponentMapper componentMapper;
+
+    @Mock
+    ComponentRepository componentRepository;
+
+    @InjectMocks
+    ComponentService componentService;
+
+    Component component = INPUT_COMPONENT.생성();
+
+    static Stream<DetailInput> provideDetailInputs() {
+        final AuthPrincipal authPrincipal = AuthPrincipal.from(KIM.생성(1L));
+        return Stream.of(
+                new DetailInput("비회원", null, false),
+                new DetailInput("회원 (북마크 X)", authPrincipal, false),
+                new DetailInput("회원 (북마크 O)", authPrincipal, true)
+        );
+    }
+
+    static Stream<SearchInput> provideSearchInputs() {
+        final AuthPrincipal authPrincipal = AuthPrincipal.from(KIM.생성(1L));
+        return Stream.of(
+                new SearchInput("비회원, 필터 X", null, "검색어", null),
+                new SearchInput("비회원, 필터 O", null, "검색어", List.of(ComponentType.INPUT)),
+                new SearchInput("회원, 필터 X", authPrincipal, "검색어", null),
+                new SearchInput("회원, 필터 O", authPrincipal, "검색어", List.of(ComponentType.INPUT))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideDetailInputs")
+    @DisplayName("컴포넌트 상세 조회")
+    public void getComponentDetail(final DetailInput input) throws Exception {
+        // given
+        final Long componentId = component.getId();
+        final ComponentViewCountIncreaseEvent event = ComponentViewCountIncreaseEvent.from(component);
+        final ComponentDetailResponse expect = new ComponentDetailResponse(
+                component.getSummary().getTitle(),
+                Collections.emptyList(),
+                component.getSummary().getDescription(),
+                component.getCommentCount().getValue(),
+                component.getBookmarkCount().getValue(),
+                component.getDesignReferenceCount().getValue(),
+                component.getSummary().getThumbnail().getImage().toUrl(),
+                Collections.emptyMap(),
+                input.isBookmarked
+        );
+
+        // when
+        doReturn(Optional.of(component)).when(componentRepository)
+                .findById(componentId);
+        doNothing().when(eventPublisher)
+                .publishEvent(event);
+        doReturn(expect).when(componentMapper)
+                .mapFrom(component, input.isBookmarked);
+        if (input.isBookmarked) {
+            doReturn(true).when(bookmarkRepository)
+                    .existsByComponentIdAndMemberId(componentId, input.authPrincipal.id());
+        }
+
+        final ComponentDetailResponse actual = componentService.getComponentDetail(input.authPrincipal, componentId);
+
+        // then
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideDetailInputs")
+    @DisplayName("컴포넌트 상세 조회 시 componentId 가 잘못된 경우 예외 발생")
+    public void getComponentDetailWhenInvalidComponentId(final DetailInput input) throws Exception {
+        // given
+        final Long componentId = component.getId();
+
+        // when
+        doReturn(Optional.empty()).when(componentRepository)
+                .findById(componentId);
+
+        // then
+        assertThatThrownBy(() -> componentService.getComponentDetail(input.authPrincipal, componentId))
+                .isInstanceOf(NotFoundComponentException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSearchInputs")
+    @DisplayName("컴포넌트 검색")
+    public void search(final SearchInput input) throws Exception {
+        // given
+        final AuthPrincipal authPrincipal = input.authPrincipal;
+        final String keyword = input.keyword;
+        final List<ComponentType> types = input.types;
+        final ComponentSearchRequest request = input.toRequest();
+        final Pageable pageable = input.pageable;
+        final Page<ComponentSummaryDao> page = new PageImpl<>(Collections.emptyList(), pageable, 0L);
+
+        // when
+        switch (input.displayName) {
+            case "비회원, 필터 X" -> doReturn(page).when(componentRepository)
+                    .searchByKeyword(keyword, pageable);
+            case "비회원, 필터 O" -> doReturn(page).when(componentRepository)
+                    .searchByKeywordWithTypes(keyword, types, pageable);
+            case "회원, 필터 X" -> doReturn(page).when(componentRepository)
+                    .searchWithBookmark(authPrincipal.id(), keyword, pageable);
+            case "회원, 필터 O" -> doReturn(page).when(componentRepository)
+                    .searchWithBookmarkAndTypes(authPrincipal.id(), keyword, types, pageable);
+            default -> throw new IllegalStateException("Unexpected value: " + input.displayName);
+        }
+
+        final PageResponse<ComponentSummaryResponse> actual = componentService.search(authPrincipal, request, pageable);
+
+        // then
+        assertThat(actual).isNotNull();
+        switch (input.displayName) {
+            case "비회원, 필터 X" -> verify(componentRepository)
+                    .searchByKeyword(keyword, pageable);
+            case "비회원, 필터 O" -> verify(componentRepository)
+                    .searchByKeywordWithTypes(keyword, types, pageable);
+            case "회원, 필터 X" -> verify(componentRepository)
+                    .searchWithBookmark(authPrincipal.id(), keyword, pageable);
+            case "회원, 필터 O" -> verify(componentRepository)
+                    .searchWithBookmarkAndTypes(authPrincipal.id(), keyword, types, pageable);
+            default -> throw new IllegalStateException("Unexpected value: " + input.displayName);
+        }
+    }
+
+    static class DetailInput {
+        String displayName;
+        AuthPrincipal authPrincipal;
+        boolean isBookmarked;
+
+        public DetailInput(final String displayName,
+                           final AuthPrincipal authPrincipal,
+                           final boolean isBookmarked) {
+            this.displayName = displayName;
+            this.authPrincipal = authPrincipal;
+            this.isBookmarked = isBookmarked;
+        }
+    }
+
+    static class SearchInput {
+        String displayName;
+        AuthPrincipal authPrincipal;
+        String keyword;
+        List<ComponentType> types;
+        Pageable pageable;
+
+        public SearchInput(final String displayName,
+                           final AuthPrincipal authPrincipal,
+                           final String keyword,
+                           final List<ComponentType> types) {
+            this.displayName = displayName;
+            this.authPrincipal = authPrincipal;
+            this.keyword = keyword;
+            this.types = types;
+            this.pageable = Pageable.unpaged();
+        }
+
+        public ComponentSearchRequest toRequest() {
+            return new ComponentSearchRequest(keyword, types);
+        }
+    }
+}

--- a/src/test/java/ject/componote/domain/component/application/ComponentServiceTest.java
+++ b/src/test/java/ject/componote/domain/component/application/ComponentServiceTest.java
@@ -90,7 +90,7 @@ class ComponentServiceTest {
                 component.getCommentCount().getValue(),
                 component.getBookmarkCount().getValue(),
                 component.getDesignReferenceCount().getValue(),
-                component.getSummary().getThumbnail().getImage().toUrl(),
+                component.getSummary().getThumbnail().toUrl(),
                 Collections.emptyMap(),
                 input.isBookmarked
         );

--- a/src/test/java/ject/componote/domain/component/application/ComponentViewCountEventHandlerTest.java
+++ b/src/test/java/ject/componote/domain/component/application/ComponentViewCountEventHandlerTest.java
@@ -1,0 +1,67 @@
+package ject.componote.domain.component.application;
+
+import ject.componote.domain.common.model.Count;
+import ject.componote.domain.component.dao.ComponentRepository;
+import ject.componote.domain.component.domain.Component;
+import ject.componote.domain.component.dto.find.event.ComponentViewCountIncreaseEvent;
+import ject.componote.domain.component.error.NotFoundComponentException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static ject.componote.fixture.ComponentFixture.INPUT_COMPONENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class ComponentViewCountEventHandlerTest {
+    @Mock
+    ComponentRepository componentRepository;
+
+    @InjectMocks
+    ComponentViewCountEventHandler componentViewCountEventHandler;
+
+    Component component = INPUT_COMPONENT.생성();
+
+    @Test
+    @DisplayName("조회 수 증가")
+    public void handleViewCountIncrease() throws Exception {
+        // given
+        final ComponentViewCountIncreaseEvent event = ComponentViewCountIncreaseEvent.from(component);
+        final Long componentId = component.getId();
+        final Count previousViewCount = component.getViewCount();
+
+        // when
+        doReturn(Optional.of(component)).when(componentRepository)
+                .findById(componentId);
+        componentViewCountEventHandler.handleViewCountIncrease(event);
+
+        // then
+        final Count newViewCount = component.getViewCount();
+        previousViewCount.increase();
+        assertThat(previousViewCount).isEqualTo(newViewCount);
+    }
+
+    @Test
+    @DisplayName("조회 수 증가 시 componentId 가 잘못된 경우 예외 발생")
+    public void handleViewCountIncreaseWhenInvalidComponentId() throws Exception {
+        // given
+        final ComponentViewCountIncreaseEvent event = ComponentViewCountIncreaseEvent.from(component);
+        final Long componentId = component.getId();
+
+        // when
+        doReturn(Optional.empty()).when(componentRepository)
+                .findById(componentId);
+
+        // then
+        assertThatThrownBy(() -> componentViewCountEventHandler.handleViewCountIncrease(event))
+                .isInstanceOf(NotFoundComponentException.class);
+
+    }
+}

--- a/src/test/java/ject/componote/domain/component/model/ComponentImageTest.java
+++ b/src/test/java/ject/componote/domain/component/model/ComponentImageTest.java
@@ -1,0 +1,31 @@
+package ject.componote.domain.component.model;
+
+import ject.componote.domain.component.error.InvalidComponentImageExtensionException;
+import ject.componote.domain.component.error.NotFoundComponentImageException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ComponentImageTest {
+    @ParameterizedTest(name = "값: {0}")
+    @DisplayName("확장자가 잘못된 경우")
+    @ValueSource(strings = {"hello.gif", "hello", "hello.jqp"})
+    public void invalidExtension(final String objectKey) {
+        assertThatThrownBy(() -> ComponentImage.from(objectKey))
+                .isInstanceOf(InvalidComponentImageExtensionException.class);
+    }
+
+    @Test
+    @DisplayName("objectKey가 전달되지 않으면 예외 발생")
+    public void createDefault() {
+        // given
+        final String objectKey = null;
+
+        // then
+        assertThatThrownBy(() -> ComponentImage.from(objectKey))
+                .isInstanceOf(NotFoundComponentImageException.class);
+    }
+}

--- a/src/test/java/ject/componote/domain/component/model/ComponentThumbnailTest.java
+++ b/src/test/java/ject/componote/domain/component/model/ComponentThumbnailTest.java
@@ -1,0 +1,31 @@
+package ject.componote.domain.component.model;
+
+import ject.componote.domain.component.error.InvalidComponentThumbnailExtensionException;
+import ject.componote.domain.component.error.NotFoundComponentThumbnailException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ComponentThumbnailTest {
+    @ParameterizedTest(name = "값: {0}")
+    @DisplayName("확장자가 잘못된 경우")
+    @ValueSource(strings = {"hello.gif", "hello", "hello.jqp"})
+    public void invalidExtension(final String objectKey) {
+        assertThatThrownBy(() -> ComponentThumbnail.from(objectKey))
+                .isInstanceOf(InvalidComponentThumbnailExtensionException.class);
+    }
+
+    @Test
+    @DisplayName("objectKey가 전달되지 않으면 예외 발생")
+    public void createDefault() {
+        // given
+        final String objectKey = null;
+
+        // then
+        assertThatThrownBy(() -> ComponentThumbnail.from(objectKey))
+                .isInstanceOf(NotFoundComponentThumbnailException.class);
+    }
+}

--- a/src/test/java/ject/componote/domain/component/util/ComponentMapperTest.java
+++ b/src/test/java/ject/componote/domain/component/util/ComponentMapperTest.java
@@ -34,6 +34,6 @@ class ComponentMapperTest {
         assertThat(response.commentCount()).isEqualTo(component.getCommentCount().getValue());
         assertThat(response.title()).isEqualTo(component.getSummary().getTitle());
         assertThat(response.description()).isEqualTo(component.getSummary().getDescription());
-        assertThat(response.thumbnailUrl()).isEqualTo(component.getSummary().getThumbnail().getImage().toUrl());
+        assertThat(response.thumbnailUrl()).isEqualTo(component.getSummary().getThumbnail().toUrl());
     }
 }

--- a/src/test/java/ject/componote/domain/component/util/ComponentMapperTest.java
+++ b/src/test/java/ject/componote/domain/component/util/ComponentMapperTest.java
@@ -1,0 +1,39 @@
+package ject.componote.domain.component.util;
+
+import ject.componote.domain.component.domain.Component;
+import ject.componote.domain.component.dto.find.response.ComponentDetailResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static ject.componote.fixture.ComponentFixture.INPUT_COMPONENT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class ComponentMapperTest {
+    @InjectMocks
+    ComponentMapper componentMapper;
+
+    @ParameterizedTest
+    @DisplayName("Component를 ComponentDetailResponse로 변환")
+    @ValueSource(booleans = {true, false})
+    public void mapFromWithBookmark(final boolean isBookmarked) throws Exception {
+        // given
+        final Component component = INPUT_COMPONENT.생성();
+
+        // when
+        final ComponentDetailResponse response = componentMapper.mapFrom(component, isBookmarked);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.isBookmarked()).isEqualTo(isBookmarked);
+        assertThat(response.bookmarkCount()).isEqualTo(component.getBookmarkCount().getValue());
+        assertThat(response.commentCount()).isEqualTo(component.getCommentCount().getValue());
+        assertThat(response.title()).isEqualTo(component.getSummary().getTitle());
+        assertThat(response.description()).isEqualTo(component.getSummary().getDescription());
+        assertThat(response.thumbnailUrl()).isEqualTo(component.getSummary().getThumbnail().getImage().toUrl());
+    }
+}

--- a/src/test/java/ject/componote/fixture/ComponentFixture.java
+++ b/src/test/java/ject/componote/fixture/ComponentFixture.java
@@ -1,0 +1,29 @@
+package ject.componote.fixture;
+
+import ject.componote.domain.component.domain.Component;
+import ject.componote.domain.component.domain.ComponentType;
+
+import java.util.Collections;
+import java.util.List;
+
+public enum ComponentFixture {
+    INPUT_COMPONENT("input title", "input description", "objectKey.jpg", ComponentType.INPUT, List.of("hello"));
+
+    private final String title;
+    private final String description;
+    private final String thumbnailObjectKey;
+    private final ComponentType type;
+    private final List<String> mixedNames;
+
+    ComponentFixture(final String title, final String description, final String thumbnailObjectKey, final ComponentType type, final List<String> mixedNames) {
+        this.title = title;
+        this.description = description;
+        this.thumbnailObjectKey = thumbnailObjectKey;
+        this.type = type;
+        this.mixedNames = mixedNames;
+    }
+
+    public Component 생성() {
+        return Component.of(title, description, thumbnailObjectKey, type, mixedNames, Collections.emptyList());
+    }
+}


### PR DESCRIPTION
## 작업 내용
- `Component` 엔티티에 필드 추가
  - 해당 컴포넌트가 디자인 시스템에서 사용되는 수  (`designReferenceCount`)
  - 조회 수 (`ViewCount`)
- 컴포넌트 상세 조회
  - Spring Event 기반 조회 수 증가
    - `@DynamicUpdate` + 변경 감지를 통해 UPDATE SQL 처리
  - `ComponentMapper` 를 통해 엔티티 -> DTO 변환
- 컴포넌트 검색
  - `ComponentSearchStrategy`을 통해 조건에 알맞는 메서드 호출 (회원의 경우 북마크 고려)
    - 비회원, Type 필터 X
    - 비회원, Type 필터 O
    - 회원, Type 필터 X
    - 회원, Type 필터 O
  - QueryDSL을 통해 적절한 DAO 반환 후
    -  Service 레이어에서 DTO로 매핑
    - 1:N 중복 데이터 처리를 위해 `distinct` 키워드 사용
- `ComponentDesign` 엔티티 추가
  - 다대다 관계인 `Component`와 `Design`의 중간 테이블 역할 담당
  - 디자인 시스템에서 특정 컴포넌트가 사용되는 횟수는 `designReferenceCount` 으로 별도 관리 (북마크, 댓글 좋아요 수 와 동일)
- `AbstractImage` 추가
  - 모든 이미지 VO 객체의 부모 클래스
  - 컴포넌트 썸네일, 댓글 사진, 프로필 사진 등 사진 VO는 해당 클래스를 상속받도록 수정
  - 기존 방식은 `BaseImage` 객체 합성을 사용했는데 객체 그래프 탐색이 너무 길어져 추상 클래스를 도입

## 테스트
### Repository
- 작성 중
### Service
<img width="825" alt="image" src="https://github.com/user-attachments/assets/e3cfb7cf-0389-4831-95dc-145f14fe4f5f" />

### Controller
__검색__
<img width="1239" alt="image" src="https://github.com/user-attachments/assets/8d5622ae-7bb4-4e37-9009-96340493b095" />

__상세 페이지__
<img width="1244" alt="image" src="https://github.com/user-attachments/assets/06d961a0-bdf5-4929-8c73-e363bfbbd332" />


## 기타 사항 (참고 자료, 문의 사항 등)
- 없음
