### PR TITLE
J01 51 be 이메일 인증

### DIFF
--- a/src/main/java/ject/componote/domain/auth/api/AuthController.java
+++ b/src/main/java/ject/componote/domain/auth/api/AuthController.java
@@ -6,9 +6,7 @@ import ject.componote.domain.auth.dto.login.request.MemberLoginRequest;
 import ject.componote.domain.auth.dto.login.response.MemberLoginResponse;
 import ject.componote.domain.auth.dto.signup.request.MemberSignupRequest;
 import ject.componote.domain.auth.dto.signup.response.MemberSignupResponse;
-import ject.componote.domain.auth.dto.verify.request.MemberSendVerificationCodeRequest;
 import ject.componote.domain.auth.dto.validate.request.MemberNicknameValidateRequest;
-import ject.componote.domain.auth.dto.verify.request.MemberEmailVerifyRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,23 +33,9 @@ public class AuthController {
         );
     }
 
-    @PostMapping("/email")
-    public ResponseEntity<Void> sendVerificationCode(@RequestBody @Valid final MemberSendVerificationCodeRequest request) {
-        authService.sendVerificationCode(request);
-        return ResponseEntity.noContent()
-                .build();
-    }
-
     @PostMapping("/nickname/validation")
     public ResponseEntity<Void> validateNickname(@RequestBody @Valid final MemberNicknameValidateRequest request) {
         authService.validateNickname(request);
-        return ResponseEntity.noContent()
-                .build();
-    }
-
-    @PostMapping("/email/verification")
-    public ResponseEntity<Void> verifyEmailCode(@RequestBody @Valid final MemberEmailVerifyRequest request) {
-        authService.verifyEmailCode(request);
         return ResponseEntity.noContent()
                 .build();
     }

--- a/src/main/java/ject/componote/domain/auth/api/AuthController.java
+++ b/src/main/java/ject/componote/domain/auth/api/AuthController.java
@@ -8,6 +8,7 @@ import ject.componote.domain.auth.dto.signup.request.MemberSignupRequest;
 import ject.componote.domain.auth.dto.signup.response.MemberSignupResponse;
 import ject.componote.domain.auth.dto.validate.request.MemberEmailValidateRequest;
 import ject.componote.domain.auth.dto.validate.request.MemberNicknameValidateRequest;
+import ject.componote.domain.auth.dto.verify.request.MemberEmailVerifyRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,6 +45,13 @@ public class AuthController {
     @PostMapping("/validations/nickname")
     public ResponseEntity<Void> validateNickname(@RequestBody @Valid final MemberNicknameValidateRequest request) {
         authService.validateNickname(request);
+        return ResponseEntity.noContent()
+                .build();
+    }
+
+    @PostMapping("/email/verification")
+    public ResponseEntity<Void> verifyEmailCode(@RequestBody @Valid final MemberEmailVerifyRequest request) {
+        authService.verifyEmailCode(request);
         return ResponseEntity.noContent()
                 .build();
     }

--- a/src/main/java/ject/componote/domain/auth/api/AuthController.java
+++ b/src/main/java/ject/componote/domain/auth/api/AuthController.java
@@ -6,7 +6,7 @@ import ject.componote.domain.auth.dto.login.request.MemberLoginRequest;
 import ject.componote.domain.auth.dto.login.response.MemberLoginResponse;
 import ject.componote.domain.auth.dto.signup.request.MemberSignupRequest;
 import ject.componote.domain.auth.dto.signup.response.MemberSignupResponse;
-import ject.componote.domain.auth.dto.validate.request.MemberEmailValidateRequest;
+import ject.componote.domain.auth.dto.verify.request.MemberSendVerificationCodeRequest;
 import ject.componote.domain.auth.dto.validate.request.MemberNicknameValidateRequest;
 import ject.componote.domain.auth.dto.verify.request.MemberEmailVerifyRequest;
 import lombok.RequiredArgsConstructor;
@@ -35,14 +35,14 @@ public class AuthController {
         );
     }
 
-    @PostMapping("/validations/email")
-    public ResponseEntity<Void> validateEmail(@RequestBody @Valid final MemberEmailValidateRequest request) {
-        authService.validateEmail(request);
+    @PostMapping("/email")
+    public ResponseEntity<Void> sendVerificationCode(@RequestBody @Valid final MemberSendVerificationCodeRequest request) {
+        authService.sendVerificationCode(request);
         return ResponseEntity.noContent()
                 .build();
     }
 
-    @PostMapping("/validations/nickname")
+    @PostMapping("/nickname/validation")
     public ResponseEntity<Void> validateNickname(@RequestBody @Valid final MemberNicknameValidateRequest request) {
         authService.validateNickname(request);
         return ResponseEntity.noContent()

--- a/src/main/java/ject/componote/domain/auth/api/MemberController.java
+++ b/src/main/java/ject/componote/domain/auth/api/MemberController.java
@@ -5,12 +5,15 @@ import ject.componote.domain.auth.application.MemberService;
 import ject.componote.domain.auth.dto.find.response.MemberSummaryResponse;
 import ject.componote.domain.auth.dto.update.request.MemberNicknameUpdateRequest;
 import ject.componote.domain.auth.dto.update.request.MemberProfileImageUpdateRequest;
+import ject.componote.domain.auth.dto.update.request.MemberEmailUpdateRequest;
+import ject.componote.domain.auth.dto.verify.request.MemberEmailVerificationRequest;
 import ject.componote.domain.auth.model.AuthPrincipal;
 import ject.componote.domain.auth.model.Authenticated;
 import ject.componote.domain.auth.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,6 +45,21 @@ public class MemberController {
     public ResponseEntity<Void> updateProfileImage(@Authenticated final AuthPrincipal authPrincipal,
                                                    @RequestBody @Valid final MemberNicknameUpdateRequest request) {
         memberService.updateNickname(authPrincipal, request);
+        return ResponseEntity.noContent()
+                .build();
+    }
+
+    @PutMapping("/email")
+    public ResponseEntity<Void> updateEmail(@Authenticated final AuthPrincipal authPrincipal,
+                                            @RequestBody @Valid final MemberEmailUpdateRequest request) {
+        memberService.updateEmail(authPrincipal, request);
+        return ResponseEntity.noContent()
+                .build();
+    }
+
+    @PostMapping("/email/verification")
+    public ResponseEntity<Void> sendVerificationCode(@RequestBody @Valid final MemberEmailVerificationRequest request) {
+        memberService.sendVerificationCode(request);
         return ResponseEntity.noContent()
                 .build();
     }

--- a/src/main/java/ject/componote/domain/auth/api/MemberController.java
+++ b/src/main/java/ject/componote/domain/auth/api/MemberController.java
@@ -58,8 +58,9 @@ public class MemberController {
     }
 
     @PostMapping("/email/verification")
-    public ResponseEntity<Void> sendVerificationCode(@RequestBody @Valid final MemberEmailVerificationRequest request) {
-        memberService.sendVerificationCode(request);
+    public ResponseEntity<Void> sendVerificationCode(@Authenticated final AuthPrincipal authPrincipal,
+                                                     @RequestBody @Valid final MemberEmailVerificationRequest request) {
+        memberService.sendVerificationCode(authPrincipal, request);
         return ResponseEntity.noContent()
                 .build();
     }

--- a/src/main/java/ject/componote/domain/auth/application/AuthService.java
+++ b/src/main/java/ject/componote/domain/auth/application/AuthService.java
@@ -7,9 +7,7 @@ import ject.componote.domain.auth.dto.login.request.MemberLoginRequest;
 import ject.componote.domain.auth.dto.login.response.MemberLoginResponse;
 import ject.componote.domain.auth.dto.signup.request.MemberSignupRequest;
 import ject.componote.domain.auth.dto.signup.response.MemberSignupResponse;
-import ject.componote.domain.auth.dto.verify.request.MemberSendVerificationCodeRequest;
 import ject.componote.domain.auth.dto.validate.request.MemberNicknameValidateRequest;
-import ject.componote.domain.auth.dto.verify.request.MemberEmailVerifyRequest;
 import ject.componote.domain.auth.error.DuplicatedNicknameException;
 import ject.componote.domain.auth.error.DuplicatedSignupException;
 import ject.componote.domain.auth.error.NotFoundMemberException;
@@ -18,7 +16,6 @@ import ject.componote.domain.auth.model.AuthPrincipal;
 import ject.componote.domain.auth.model.Nickname;
 import ject.componote.domain.auth.util.TokenProvider;
 import ject.componote.infra.file.application.FileService;
-import ject.componote.infra.mail.application.MailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -26,7 +23,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class AuthService {
     private final FileService fileService;
-    private final MailService mailService;
     private final MemberRepository memberRepository;
     private final SocialAccountRepository socialAccountRepository;
     private final TokenProvider tokenProvider;
@@ -54,19 +50,11 @@ public class AuthService {
         return MemberLoginResponse.of(accessToken, member);
     }
 
-    public void sendVerificationCode(final MemberSendVerificationCodeRequest request) {
-        mailService.sendVerificationCode(request.email());
-    }
-
     public void validateNickname(final MemberNicknameValidateRequest request) {
         final Nickname nickname = Nickname.from(request.nickname());
         if (memberRepository.existsByNickname(nickname)) {
             throw new DuplicatedNicknameException(nickname);
         }
-    }
-
-    public void verifyEmailCode(final MemberEmailVerifyRequest request) {
-        mailService.verifyEmailCode(request.email(), request.verificationCode());
     }
 
     private Member findMemberBySocialAccountId(final Long socialAccountId) {

--- a/src/main/java/ject/componote/domain/auth/application/AuthService.java
+++ b/src/main/java/ject/componote/domain/auth/application/AuthService.java
@@ -7,7 +7,7 @@ import ject.componote.domain.auth.dto.login.request.MemberLoginRequest;
 import ject.componote.domain.auth.dto.login.response.MemberLoginResponse;
 import ject.componote.domain.auth.dto.signup.request.MemberSignupRequest;
 import ject.componote.domain.auth.dto.signup.response.MemberSignupResponse;
-import ject.componote.domain.auth.dto.validate.request.MemberEmailValidateRequest;
+import ject.componote.domain.auth.dto.verify.request.MemberSendVerificationCodeRequest;
 import ject.componote.domain.auth.dto.validate.request.MemberNicknameValidateRequest;
 import ject.componote.domain.auth.dto.verify.request.MemberEmailVerifyRequest;
 import ject.componote.domain.auth.error.DuplicatedNicknameException;
@@ -18,6 +18,7 @@ import ject.componote.domain.auth.model.AuthPrincipal;
 import ject.componote.domain.auth.model.Nickname;
 import ject.componote.domain.auth.util.TokenProvider;
 import ject.componote.infra.file.application.FileService;
+import ject.componote.infra.mail.application.MailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -53,8 +54,8 @@ public class AuthService {
         return MemberLoginResponse.of(accessToken, member);
     }
 
-    public void validateEmail(final MemberEmailValidateRequest request) {
-
+    public void sendVerificationCode(final MemberSendVerificationCodeRequest request) {
+        mailService.sendVerificationCode(request.email());
     }
 
     public void validateNickname(final MemberNicknameValidateRequest request) {

--- a/src/main/java/ject/componote/domain/auth/application/AuthService.java
+++ b/src/main/java/ject/componote/domain/auth/application/AuthService.java
@@ -9,6 +9,7 @@ import ject.componote.domain.auth.dto.signup.request.MemberSignupRequest;
 import ject.componote.domain.auth.dto.signup.response.MemberSignupResponse;
 import ject.componote.domain.auth.dto.validate.request.MemberEmailValidateRequest;
 import ject.componote.domain.auth.dto.validate.request.MemberNicknameValidateRequest;
+import ject.componote.domain.auth.dto.verify.request.MemberEmailVerifyRequest;
 import ject.componote.domain.auth.error.DuplicatedNicknameException;
 import ject.componote.domain.auth.error.DuplicatedSignupException;
 import ject.componote.domain.auth.error.NotFoundMemberException;
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class AuthService {
     private final FileService fileService;
+    private final MailService mailService;
     private final MemberRepository memberRepository;
     private final SocialAccountRepository socialAccountRepository;
     private final TokenProvider tokenProvider;
@@ -60,6 +62,10 @@ public class AuthService {
         if (memberRepository.existsByNickname(nickname)) {
             throw new DuplicatedNicknameException(nickname);
         }
+    }
+
+    public void verifyEmailCode(final MemberEmailVerifyRequest request) {
+        mailService.verifyEmailCode(request.email(), request.verificationCode());
     }
 
     private Member findMemberBySocialAccountId(final Long socialAccountId) {

--- a/src/main/java/ject/componote/domain/auth/application/MemberService.java
+++ b/src/main/java/ject/componote/domain/auth/application/MemberService.java
@@ -77,7 +77,7 @@ public class MemberService {
         member.updateEmail(email);
     }
 
-    public void sendVerificationCode(final AuthPrincipal authPrincipal,final MemberEmailVerificationRequest request) {
+    public void sendVerificationCode(final AuthPrincipal authPrincipal, final MemberEmailVerificationRequest request) {
         final Email email = Email.from(request.email());
         validateDuplicatedEmail(email);
 

--- a/src/main/java/ject/componote/domain/auth/application/MemberService.java
+++ b/src/main/java/ject/componote/domain/auth/application/MemberService.java
@@ -1,16 +1,22 @@
 package ject.componote.domain.auth.application;
 
-import ject.componote.domain.auth.domain.Member;
 import ject.componote.domain.auth.dao.MemberRepository;
+import ject.componote.domain.auth.domain.Member;
 import ject.componote.domain.auth.dto.find.response.MemberSummaryResponse;
+import ject.componote.domain.auth.dto.update.request.MemberEmailUpdateRequest;
 import ject.componote.domain.auth.dto.update.request.MemberNicknameUpdateRequest;
 import ject.componote.domain.auth.dto.update.request.MemberProfileImageUpdateRequest;
+import ject.componote.domain.auth.dto.verify.request.MemberEmailVerificationRequest;
+import ject.componote.domain.auth.error.DuplicatedEmailException;
 import ject.componote.domain.auth.error.DuplicatedNicknameException;
 import ject.componote.domain.auth.error.NotFoundMemberException;
+import ject.componote.domain.auth.error.SameEmailUpdateException;
 import ject.componote.domain.auth.model.AuthPrincipal;
+import ject.componote.domain.auth.model.Email;
 import ject.componote.domain.auth.model.Nickname;
 import ject.componote.domain.auth.model.ProfileImage;
 import ject.componote.infra.file.application.FileService;
+import ject.componote.infra.mail.application.MailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberService {
     private final FileService fileService;
+    private final MailService mailService;
     private final MemberRepository memberRepository;
 
     public MemberSummaryResponse getMemberSummary(final AuthPrincipal authPrincipal) {
@@ -58,8 +65,37 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    public Member findMemberById(final Long memberId) {
+    @Transactional
+    public void updateEmail(final AuthPrincipal authPrincipal, final MemberEmailUpdateRequest request) {
+        validateDuplicatedEmail(request.email());
+        mailService.verifyEmailCode(request.email(), request.verificationCode());
+
+        final Email email = Email.from(request.email());
+        final Member member = findMemberById(authPrincipal.id());
+        validateSameEmail(member, email);
+        member.updateEmail(email);
+    }
+
+    public void sendVerificationCode(final MemberEmailVerificationRequest request) {
+        validateDuplicatedEmail(request.email());
+        mailService.sendVerificationCode(request.email());
+    }
+
+    private Member findMemberById(final Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> NotFoundMemberException.createWhenInvalidMemberId(memberId));
+    }
+
+    private void validateSameEmail(final Member member, final Email newEmail) {
+        if (member.equalsEmail(newEmail)) {
+            throw new SameEmailUpdateException();
+        }
+    }
+
+    private void validateDuplicatedEmail(final String emailValue) {
+        final Email email = Email.from(emailValue);
+        if (memberRepository.existsByEmail(email)) {
+            throw new DuplicatedEmailException(email);
+        }
     }
 }

--- a/src/main/java/ject/componote/domain/auth/dao/MemberRepository.java
+++ b/src/main/java/ject/componote/domain/auth/dao/MemberRepository.java
@@ -1,6 +1,7 @@
 package ject.componote.domain.auth.dao;
 
 import ject.componote.domain.auth.domain.Member;
+import ject.componote.domain.auth.model.Email;
 import ject.componote.domain.auth.model.Nickname;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,10 +13,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsBySocialAccountId(final Long socialAccountId);
     Optional<Member> findBySocialAccountId(final Long socialAccountId);
 
-    @Query("SELECT NEW ject.componote.domain.auth.dao.MemberSummaryDao(m.nickname, m.profileImage) " +
+    @Query("SELECT NEW ject.componote.domain.auth.dao.MemberSummaryDao(m.email, m.nickname, m.profileImage) " +
             "FROM Member m " +
             "WHERE m.id =:id")
     Optional<MemberSummaryDao> findSummaryById(@Param("id") final Long id);
 
     boolean existsByNickname(final Nickname nickname);
+    boolean existsByEmail(final Email email);
 }

--- a/src/main/java/ject/componote/domain/auth/dao/MemberSummaryDao.java
+++ b/src/main/java/ject/componote/domain/auth/dao/MemberSummaryDao.java
@@ -1,7 +1,8 @@
 package ject.componote.domain.auth.dao;
 
+import ject.componote.domain.auth.model.Email;
 import ject.componote.domain.auth.model.Nickname;
 import ject.componote.domain.auth.model.ProfileImage;
 
-public record MemberSummaryDao(Nickname nickname, ProfileImage profileImage) {
+public record MemberSummaryDao(Email email, Nickname nickname, ProfileImage profileImage) {
 }

--- a/src/main/java/ject/componote/domain/auth/domain/Member.java
+++ b/src/main/java/ject/componote/domain/auth/domain/Member.java
@@ -21,6 +21,8 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.DynamicUpdate;
 
+import java.util.Objects;
+
 @DynamicUpdate
 @Entity
 @Getter
@@ -79,7 +81,7 @@ public class Member extends BaseEntity {
     }
 
     public boolean equalsEmail(final Email email) {
-        return this.email.equals(email);
+        return Objects.equals(this.email, email);
     }
 
     public void updateProfileImage(final ProfileImage profileImage) {

--- a/src/main/java/ject/componote/domain/auth/domain/Member.java
+++ b/src/main/java/ject/componote/domain/auth/domain/Member.java
@@ -19,7 +19,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.DynamicUpdate;
 
+@DynamicUpdate
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -76,11 +78,19 @@ public class Member extends BaseEntity {
         return this.profileImage.equals(profileImage);
     }
 
+    public boolean equalsEmail(final Email email) {
+        return this.email.equals(email);
+    }
+
     public void updateProfileImage(final ProfileImage profileImage) {
         this.profileImage = profileImage;
     }
 
     public void updateNickname(final Nickname nickname) {
         this.nickname = nickname;
+    }
+
+    public void updateEmail(final Email email) {
+        this.email = email;
     }
 }

--- a/src/main/java/ject/componote/domain/auth/dto/find/response/MemberSummaryResponse.java
+++ b/src/main/java/ject/componote/domain/auth/dto/find/response/MemberSummaryResponse.java
@@ -2,9 +2,10 @@ package ject.componote.domain.auth.dto.find.response;
 
 import ject.componote.domain.auth.dao.MemberSummaryDao;
 
-public record MemberSummaryResponse(String nickname, String profileImageUrl) {
-    public static MemberSummaryResponse from(MemberSummaryDao memberSummaryDao) {
+public record MemberSummaryResponse(boolean isEmailRegistered, String nickname, String profileImageUrl) {
+    public static MemberSummaryResponse from(final MemberSummaryDao memberSummaryDao) {
         return new MemberSummaryResponse(
+                memberSummaryDao.email() != null,   // 좀 애매한 것 같음
                 memberSummaryDao.nickname().getValue(),
                 memberSummaryDao.profileImage().toUrl()
         );

--- a/src/main/java/ject/componote/domain/auth/dto/update/request/MemberEmailUpdateRequest.java
+++ b/src/main/java/ject/componote/domain/auth/dto/update/request/MemberEmailUpdateRequest.java
@@ -1,0 +1,7 @@
+package ject.componote.domain.auth.dto.update.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberEmailUpdateRequest(@Email String email, @NotBlank String verificationCode) {
+}

--- a/src/main/java/ject/componote/domain/auth/dto/validate/request/MemberEmailValidateRequest.java
+++ b/src/main/java/ject/componote/domain/auth/dto/validate/request/MemberEmailValidateRequest.java
@@ -1,6 +1,0 @@
-package ject.componote.domain.auth.dto.validate.request;
-
-import jakarta.validation.constraints.Email;
-
-public record MemberEmailValidateRequest(@Email String email) {
-}

--- a/src/main/java/ject/componote/domain/auth/dto/verify/request/MemberEmailVerificationRequest.java
+++ b/src/main/java/ject/componote/domain/auth/dto/verify/request/MemberEmailVerificationRequest.java
@@ -2,5 +2,5 @@ package ject.componote.domain.auth.dto.verify.request;
 
 import jakarta.validation.constraints.Email;
 
-public record MemberSendVerificationCodeRequest(@Email String email) {
+public record MemberEmailVerificationRequest(@Email String email) {
 }

--- a/src/main/java/ject/componote/domain/auth/dto/verify/request/MemberEmailVerifyRequest.java
+++ b/src/main/java/ject/componote/domain/auth/dto/verify/request/MemberEmailVerifyRequest.java
@@ -1,7 +1,0 @@
-package ject.componote.domain.auth.dto.verify.request;
-
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-
-public record MemberEmailVerifyRequest(@Email String email, @NotBlank String verificationCode) {
-}

--- a/src/main/java/ject/componote/domain/auth/dto/verify/request/MemberEmailVerifyRequest.java
+++ b/src/main/java/ject/componote/domain/auth/dto/verify/request/MemberEmailVerifyRequest.java
@@ -1,0 +1,7 @@
+package ject.componote.domain.auth.dto.verify.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberEmailVerifyRequest(@Email String email, @NotBlank String verificationCode) {
+}

--- a/src/main/java/ject/componote/domain/auth/dto/verify/request/MemberSendVerificationCodeRequest.java
+++ b/src/main/java/ject/componote/domain/auth/dto/verify/request/MemberSendVerificationCodeRequest.java
@@ -1,0 +1,6 @@
+package ject.componote.domain.auth.dto.verify.request;
+
+import jakarta.validation.constraints.Email;
+
+public record MemberSendVerificationCodeRequest(@Email String email) {
+}

--- a/src/main/java/ject/componote/domain/auth/error/DuplicatedEmailException.java
+++ b/src/main/java/ject/componote/domain/auth/error/DuplicatedEmailException.java
@@ -1,0 +1,10 @@
+package ject.componote.domain.auth.error;
+
+import ject.componote.domain.auth.model.Email;
+import org.springframework.http.HttpStatus;
+
+public class DuplicatedEmailException extends AuthException {
+    public DuplicatedEmailException(final Email email) {
+        super("이미 존재하는 이메일입니다. 입력한 이메일: " + email.getValue(), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/ject/componote/domain/auth/error/SameEmailUpdateException.java
+++ b/src/main/java/ject/componote/domain/auth/error/SameEmailUpdateException.java
@@ -1,0 +1,9 @@
+package ject.componote.domain.auth.error;
+
+import org.springframework.http.HttpStatus;
+
+public class SameEmailUpdateException extends AuthException {
+    public SameEmailUpdateException() {
+        super("이메일 주소가 기존에 등록된 이메일과 동일합니다.", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/ject/componote/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/ject/componote/global/error/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import ject.componote.infra.error.InfraException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -75,6 +76,12 @@ public class GlobalExceptionHandler {
         log.warn("잘못된 요청입니다. ", exception);
         return ResponseEntity.status(BAD_REQUEST)
                 .body(ErrorResponse.of(BAD_REQUEST, "잘못된 요청입니다."));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(final HttpMessageNotReadableException exception) {
+        return ResponseEntity.status(BAD_REQUEST)
+                .body(ErrorResponse.of(BAD_REQUEST, "HTTP Request Body 가 잘못되었습니다."));
     }
 
     @ExceptionHandler(ConstraintViolationException.class)

--- a/src/main/java/ject/componote/infra/mail/application/MailService.java
+++ b/src/main/java/ject/componote/infra/mail/application/MailService.java
@@ -31,7 +31,7 @@ public class MailService {
 
     public void sendVerificationCode(final String receiverEmail) {
         final VerificationCode verificationCode = verificationCodeProvider.createVerificationCode();
-        final String htmlContent = mailTemplateProvider.createVerificationCodeTemplate(verificationCode.value());
+        final String htmlContent = mailTemplateProvider.createVerificationCodeTemplate(verificationCode);
         final MimeMessage message = createMimeMessage(receiverEmail, htmlContent);
 
         CompletableFuture.runAsync(() -> {

--- a/src/main/java/ject/componote/infra/mail/application/MailService.java
+++ b/src/main/java/ject/componote/infra/mail/application/MailService.java
@@ -6,14 +6,13 @@ import ject.componote.infra.mail.error.EmailMessageCreationException;
 import ject.componote.infra.mail.error.NotFoundVerificationCodeException;
 import ject.componote.infra.mail.model.VerificationCode;
 import ject.componote.infra.mail.repository.VerificationCodeRepository;
+import ject.componote.infra.mail.util.MailTemplateProvider;
 import ject.componote.infra.mail.util.VerificationCodeProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
-import org.thymeleaf.TemplateEngine;
-import org.thymeleaf.context.Context;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -23,31 +22,26 @@ import java.util.concurrent.ExecutorService;
 @RequiredArgsConstructor
 public class MailService {
     private static final String EMAIL_SENDING_FAIL_LOG_FORMAT = "이메일 인증 코드 발송 실패. [입력한 이메일]: {}, [메시지]: {}";
-    private static final String EMAIL_VERIFICATION_TEMPLATE = "email-verification";
-    private static final String VERIFICATION_CODE_KEY = "verificationCode";
 
     private final ExecutorService mailExecutor;
     private final JavaMailSender mailSender;
-    private final TemplateEngine templateEngine;
+    private final MailTemplateProvider mailTemplateProvider;
     private final VerificationCodeProvider verificationCodeProvider;
-    private final VerificationCodeRepository verificationCodeRepository;    // Redis 활용 예정
+    private final VerificationCodeRepository verificationCodeRepository;
 
     public void sendVerificationCode(final String receiverEmail) {
-        final VerificationCode verificationCode = verificationCodeProvider.provideVerificationCode();
-        final MimeMessage message = createMimeMessage(receiverEmail, verificationCode);
+        final VerificationCode verificationCode = verificationCodeProvider.createVerificationCode();
+        final String htmlContent = mailTemplateProvider.createVerificationCodeTemplate(verificationCode.value());
+        final MimeMessage message = createMimeMessage(receiverEmail, htmlContent);
 
-        CompletableFuture.runAsync(
-                () -> {
-                    mailSender.send(message);
-                    verificationCodeRepository.save(receiverEmail, verificationCode);
-                }, mailExecutor
-        ).exceptionally(
-                (throwable) -> {
-                    verificationCodeRepository.deleteByEmail(receiverEmail);
-                    log.error(EMAIL_SENDING_FAIL_LOG_FORMAT, receiverEmail, throwable.getMessage());
-                    return null;
-                }
-        );
+        CompletableFuture.runAsync(() -> {
+            mailSender.send(message);
+            verificationCodeRepository.save(receiverEmail, verificationCode);
+        }, mailExecutor).exceptionally(throwable -> {
+            verificationCodeRepository.deleteByEmail(receiverEmail);
+            log.error(EMAIL_SENDING_FAIL_LOG_FORMAT, receiverEmail, throwable.getMessage());
+            return null;
+        });
     }
 
     public void verifyEmailCode(final String email, final String codeValue) {
@@ -55,26 +49,19 @@ public class MailService {
         if (!verificationCode.equalsValue(codeValue)) {
             throw new NotFoundVerificationCodeException();
         }
-
         verificationCodeRepository.deleteByEmail(email);
     }
 
-    private MimeMessage createMimeMessage(final String receiverEmail, final VerificationCode verificationCode) {
+    private MimeMessage createMimeMessage(final String receiverEmail, final String htmlContent) {
         final MimeMessage message = mailSender.createMimeMessage();
         try {
             final MimeMessageHelper helper = new MimeMessageHelper(message, true);
             helper.setTo(receiverEmail);
-            helper.setText(createHtmlContent(verificationCode), true);
+            helper.setText(htmlContent, true);
             return message;
         } catch (MessagingException e) {
             throw new EmailMessageCreationException(e);
         }
-    }
-
-    private String createHtmlContent(final VerificationCode verificationCode) {
-        final Context context = new Context();
-        context.setVariable(VERIFICATION_CODE_KEY, verificationCode.value());
-        return templateEngine.process(EMAIL_VERIFICATION_TEMPLATE, context);
     }
 
     private VerificationCode findVerificationCodeByEmail(final String email) {

--- a/src/main/java/ject/componote/infra/mail/application/MailService.java
+++ b/src/main/java/ject/componote/infra/mail/application/MailService.java
@@ -35,9 +35,10 @@ public class MailService {
         final MimeMessage message = createMimeMessage(receiverEmail, htmlContent);
 
         CompletableFuture.runAsync(() -> {
-            mailSender.send(message);
-            verificationCodeRepository.save(receiverEmail, verificationCode);
-        }, mailExecutor).exceptionally(throwable -> {
+                    mailSender.send(message);
+                    verificationCodeRepository.save(receiverEmail, verificationCode);
+                }, mailExecutor
+        ).exceptionally(throwable -> {
             verificationCodeRepository.deleteByEmail(receiverEmail);
             log.error(EMAIL_SENDING_FAIL_LOG_FORMAT, receiverEmail, throwable.getMessage());
             return null;

--- a/src/main/java/ject/componote/infra/mail/application/MailService.java
+++ b/src/main/java/ject/componote/infra/mail/application/MailService.java
@@ -1,0 +1,84 @@
+package ject.componote.infra.mail.application;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import ject.componote.infra.mail.error.EmailMessageCreationException;
+import ject.componote.infra.mail.error.NotFoundVerificationCodeException;
+import ject.componote.infra.mail.model.VerificationCode;
+import ject.componote.infra.mail.repository.VerificationCodeRepository;
+import ject.componote.infra.mail.util.VerificationCodeProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MailService {
+    private static final String EMAIL_SENDING_FAIL_LOG_FORMAT = "이메일 인증 코드 발송 실패. [입력한 이메일]: {}, [메시지]: {}";
+    private static final String EMAIL_VERIFICATION_TEMPLATE = "email-verification";
+    private static final String VERIFICATION_CODE_KEY = "verificationCode";
+
+    private final ExecutorService mailExecutor;
+    private final JavaMailSender mailSender;
+    private final TemplateEngine templateEngine;
+    private final VerificationCodeProvider verificationCodeProvider;
+    private final VerificationCodeRepository verificationCodeRepository;    // Redis 활용 예정
+
+    public void sendVerificationCode(final String receiverEmail) {
+        final VerificationCode verificationCode = verificationCodeProvider.provideVerificationCode();
+        final MimeMessage message = createMimeMessage(receiverEmail, verificationCode);
+
+        CompletableFuture.runAsync(
+                () -> {
+                    mailSender.send(message);
+                    verificationCodeRepository.save(receiverEmail, verificationCode);
+                }, mailExecutor
+        ).exceptionally(
+                (throwable) -> {
+                    verificationCodeRepository.deleteByEmail(receiverEmail);
+                    log.error(EMAIL_SENDING_FAIL_LOG_FORMAT, receiverEmail, throwable.getMessage());
+                    return null;
+                }
+        );
+    }
+
+    public void verifyEmailCode(final String email, final String codeValue) {
+        final VerificationCode verificationCode = findVerificationCodeByEmail(email);
+        if (!verificationCode.equalsValue(codeValue)) {
+            throw new NotFoundVerificationCodeException();
+        }
+
+        verificationCodeRepository.deleteByEmail(email);
+    }
+
+    private MimeMessage createMimeMessage(final String receiverEmail, final VerificationCode verificationCode) {
+        final MimeMessage message = mailSender.createMimeMessage();
+        try {
+            final MimeMessageHelper helper = new MimeMessageHelper(message, true);
+            helper.setTo(receiverEmail);
+            helper.setText(createHtmlContent(verificationCode), true);
+            return message;
+        } catch (MessagingException e) {
+            throw new EmailMessageCreationException(e);
+        }
+    }
+
+    private String createHtmlContent(final VerificationCode verificationCode) {
+        final Context context = new Context();
+        context.setVariable(VERIFICATION_CODE_KEY, verificationCode.value());
+        return templateEngine.process(EMAIL_VERIFICATION_TEMPLATE, context);
+    }
+
+    private VerificationCode findVerificationCodeByEmail(final String email) {
+        return verificationCodeRepository.findByEmail(email)
+                .orElseThrow(NotFoundVerificationCodeException::new);
+    }
+}

--- a/src/main/java/ject/componote/infra/mail/config/MailConfig.java
+++ b/src/main/java/ject/componote/infra/mail/config/MailConfig.java
@@ -1,0 +1,19 @@
+package ject.componote.infra.mail.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Configuration
+public class MailConfig {
+    /**
+     * 인증 코드 전송 스레드 풀 빈 등록 메서드
+     * @return 인증 코드 전송 스레드 풀
+     */
+    @Bean("mailExecutor")
+    public ExecutorService mailExecutor() {
+        return Executors.newFixedThreadPool(10);
+    }
+}

--- a/src/main/java/ject/componote/infra/mail/config/MailConfig.java
+++ b/src/main/java/ject/componote/infra/mail/config/MailConfig.java
@@ -1,5 +1,7 @@
 package ject.componote.infra.mail.config;
 
+import ject.componote.infra.mail.repository.VerificationCodeRepository;
+import ject.componote.infra.mail.repository.impl.InMemoryVerificationCodeRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,5 +17,10 @@ public class MailConfig {
     @Bean("mailExecutor")
     public ExecutorService mailExecutor() {
         return Executors.newFixedThreadPool(10);
+    }
+
+    @Bean
+    public VerificationCodeRepository verificationCodeRepository() {
+        return new InMemoryVerificationCodeRepository();
     }
 }

--- a/src/main/java/ject/componote/infra/mail/error/EmailMessageCreationException.java
+++ b/src/main/java/ject/componote/infra/mail/error/EmailMessageCreationException.java
@@ -1,0 +1,12 @@
+package ject.componote.infra.mail.error;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+
+@Slf4j
+public class EmailMessageCreationException extends MailException {
+    public EmailMessageCreationException(final Throwable throwable) {
+        super("이메일 메시지 생성에 실패했습니다.", HttpStatus.BAD_REQUEST);
+        log.warn("이메일 메시지 생성 실패: {}", throwable.getMessage());
+    }
+}

--- a/src/main/java/ject/componote/infra/mail/error/MailException.java
+++ b/src/main/java/ject/componote/infra/mail/error/MailException.java
@@ -1,0 +1,10 @@
+package ject.componote.infra.mail.error;
+
+import ject.componote.infra.error.InfraException;
+import org.springframework.http.HttpStatus;
+
+public class MailException extends InfraException {
+    public MailException(final String message, final HttpStatus status) {
+        super(message, status);
+    }
+}

--- a/src/main/java/ject/componote/infra/mail/error/NotFoundVerificationCodeException.java
+++ b/src/main/java/ject/componote/infra/mail/error/NotFoundVerificationCodeException.java
@@ -1,0 +1,9 @@
+package ject.componote.infra.mail.error;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundVerificationCodeException extends MailException {
+    public NotFoundVerificationCodeException() {
+        super("인증 코드가 만료되었거나 잘못되었습니다.", HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/ject/componote/infra/mail/model/VerificationCode.java
+++ b/src/main/java/ject/componote/infra/mail/model/VerificationCode.java
@@ -1,0 +1,13 @@
+package ject.componote.infra.mail.model;
+
+import java.time.LocalDateTime;
+
+public record VerificationCode(String value, LocalDateTime expiredAt) {
+    public boolean equalsValue(final String value) {
+        return this.value.equals(value);
+    }
+
+    public boolean isExpired() {
+        return this.expiredAt.isBefore(LocalDateTime.now());
+    }
+}

--- a/src/main/java/ject/componote/infra/mail/repository/VerificationCodeRepository.java
+++ b/src/main/java/ject/componote/infra/mail/repository/VerificationCodeRepository.java
@@ -1,0 +1,11 @@
+package ject.componote.infra.mail.repository;
+
+import ject.componote.infra.mail.model.VerificationCode;
+
+import java.util.Optional;
+
+public interface VerificationCodeRepository {
+    void save(final String email, final VerificationCode verificationCode);
+    void deleteByEmail(final String email);
+    Optional<VerificationCode> findByEmail(final String email);
+}

--- a/src/main/java/ject/componote/infra/mail/repository/impl/InMemoryVerificationCodeRepository.java
+++ b/src/main/java/ject/componote/infra/mail/repository/impl/InMemoryVerificationCodeRepository.java
@@ -2,13 +2,11 @@ package ject.componote.infra.mail.repository.impl;
 
 import ject.componote.infra.mail.model.VerificationCode;
 import ject.componote.infra.mail.repository.VerificationCodeRepository;
-import org.springframework.stereotype.Component;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-@Component
 public class InMemoryVerificationCodeRepository implements VerificationCodeRepository {
     private final Map<String, VerificationCode> storage = new ConcurrentHashMap<>();
 

--- a/src/main/java/ject/componote/infra/mail/repository/impl/InMemoryVerificationCodeRepository.java
+++ b/src/main/java/ject/componote/infra/mail/repository/impl/InMemoryVerificationCodeRepository.java
@@ -1,0 +1,39 @@
+package ject.componote.infra.mail.repository.impl;
+
+import ject.componote.infra.mail.model.VerificationCode;
+import ject.componote.infra.mail.repository.VerificationCodeRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class InMemoryVerificationCodeRepository implements VerificationCodeRepository {
+    private final Map<String, VerificationCode> storage = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(final String email, final VerificationCode verificationCode) {
+        storage.put(email, verificationCode);
+    }
+
+    @Override
+    public void deleteByEmail(final String email) {
+        storage.remove(email);
+    }
+
+    @Override
+    public Optional<VerificationCode> findByEmail(final String email) {
+        if (!storage.containsKey(email)) {
+            return Optional.empty();
+        }
+
+        final VerificationCode verificationCode = storage.get(email);
+        if (verificationCode.isExpired()) {
+            storage.remove(email);
+            return Optional.empty();
+        }
+
+        return Optional.of(verificationCode);
+    }
+}

--- a/src/main/java/ject/componote/infra/mail/util/MailTemplateProvider.java
+++ b/src/main/java/ject/componote/infra/mail/util/MailTemplateProvider.java
@@ -14,7 +14,7 @@ public class MailTemplateProvider {
     private final TemplateEngine templateEngine;
 
     public String createVerificationCodeTemplate(final String verificationCode) {
-        final Context context = new Context();
+        final Context context = new Context();  // Thread-Safe 하지 않아 매 요청마다 객체 생성
         context.setVariable(VERIFICATION_CODE_KEY, verificationCode);
         return templateEngine.process(EMAIL_VERIFICATION_TEMPLATE, context);
     }

--- a/src/main/java/ject/componote/infra/mail/util/MailTemplateProvider.java
+++ b/src/main/java/ject/componote/infra/mail/util/MailTemplateProvider.java
@@ -1,5 +1,6 @@
 package ject.componote.infra.mail.util;
 
+import ject.componote.infra.mail.model.VerificationCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.thymeleaf.TemplateEngine;
@@ -13,9 +14,9 @@ public class MailTemplateProvider {
 
     private final TemplateEngine templateEngine;
 
-    public String createVerificationCodeTemplate(final String verificationCode) {
+    public String createVerificationCodeTemplate(final VerificationCode verificationCode) {
         final Context context = new Context();  // Thread-Safe 하지 않아 매 요청마다 객체 생성
-        context.setVariable(VERIFICATION_CODE_KEY, verificationCode);
+        context.setVariable(VERIFICATION_CODE_KEY, verificationCode.value());
         return templateEngine.process(EMAIL_VERIFICATION_TEMPLATE, context);
     }
 }

--- a/src/main/java/ject/componote/infra/mail/util/MailTemplateProvider.java
+++ b/src/main/java/ject/componote/infra/mail/util/MailTemplateProvider.java
@@ -1,0 +1,21 @@
+package ject.componote.infra.mail.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Component
+@RequiredArgsConstructor
+public class MailTemplateProvider {
+    private static final String VERIFICATION_CODE_KEY = "verificationCode";
+    private static final String EMAIL_VERIFICATION_TEMPLATE = "email-verification";
+
+    private final TemplateEngine templateEngine;
+
+    public String createVerificationCodeTemplate(final String verificationCode) {
+        final Context context = new Context();
+        context.setVariable(VERIFICATION_CODE_KEY, verificationCode);
+        return templateEngine.process(EMAIL_VERIFICATION_TEMPLATE, context);
+    }
+}

--- a/src/main/java/ject/componote/infra/mail/util/VerificationCodeProvider.java
+++ b/src/main/java/ject/componote/infra/mail/util/VerificationCodeProvider.java
@@ -11,7 +11,7 @@ public class VerificationCodeProvider {
     private static final int VERIFICATION_CODE_LENGTH = 6;
     private static final long EXPIRATION_MINUTE = 5L;
 
-    public VerificationCode provideVerificationCode() {
+    public VerificationCode createVerificationCode() {
         return new VerificationCode(
                 createCode(),
                 LocalDateTime.now().plusMinutes(EXPIRATION_MINUTE)

--- a/src/main/java/ject/componote/infra/mail/util/VerificationCodeProvider.java
+++ b/src/main/java/ject/componote/infra/mail/util/VerificationCodeProvider.java
@@ -1,0 +1,26 @@
+package ject.componote.infra.mail.util;
+
+import ject.componote.infra.mail.model.VerificationCode;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Component
+public class VerificationCodeProvider {
+    private static final int VERIFICATION_CODE_LENGTH = 6;
+    private static final long EXPIRATION_MINUTE = 5L;
+
+    public VerificationCode provideVerificationCode() {
+        return new VerificationCode(
+                createCode(),
+                LocalDateTime.now().plusMinutes(EXPIRATION_MINUTE)
+        );
+    }
+
+    private String createCode() {
+        return UUID.randomUUID()
+                .toString()
+                .substring(0, VERIFICATION_CODE_LENGTH);
+    }
+}

--- a/src/test/java/ject/componote/domain/auth/application/MemberServiceTest.java
+++ b/src/test/java/ject/componote/domain/auth/application/MemberServiceTest.java
@@ -4,13 +4,17 @@ import ject.componote.domain.auth.dao.MemberRepository;
 import ject.componote.domain.auth.dao.MemberSummaryDao;
 import ject.componote.domain.auth.domain.Member;
 import ject.componote.domain.auth.dto.find.response.MemberSummaryResponse;
+import ject.componote.domain.auth.dto.update.request.MemberEmailUpdateRequest;
 import ject.componote.domain.auth.dto.update.request.MemberNicknameUpdateRequest;
 import ject.componote.domain.auth.dto.update.request.MemberProfileImageUpdateRequest;
+import ject.componote.domain.auth.dto.verify.request.MemberEmailVerificationRequest;
 import ject.componote.domain.auth.error.DuplicatedNicknameException;
 import ject.componote.domain.auth.model.AuthPrincipal;
+import ject.componote.domain.auth.model.Email;
 import ject.componote.domain.auth.model.Nickname;
 import ject.componote.domain.auth.model.ProfileImage;
 import ject.componote.infra.file.application.FileService;
+import ject.componote.infra.mail.application.MailService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,11 +28,15 @@ import java.util.Optional;
 import static ject.componote.fixture.MemberFixture.KIM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
+    @Mock
+    MailService mailService;
+
     @Mock
     FileService fileService;
 
@@ -52,7 +60,7 @@ class MemberServiceTest {
     public void getMemberSummary() throws Exception {
         // given
         final Long memberId = member.getId();
-        final MemberSummaryDao memberSummaryDao = new MemberSummaryDao(member.getNickname(), member.getProfileImage());
+        final MemberSummaryDao memberSummaryDao = new MemberSummaryDao(member.getEmail(), member.getNickname(), member.getProfileImage());
         final MemberSummaryResponse expect = MemberSummaryResponse.from(memberSummaryDao);
 
         // when
@@ -102,6 +110,52 @@ class MemberServiceTest {
 
         // then
         assertThat(member.equalsNickname(newNickname)).isTrue();
+    }
+
+    @Test
+    @DisplayName("이메일 등록/변경")
+    public void updateEmail() throws Exception {
+        // given
+        final Long memberId = member.getId();
+        final String newEmailValue = "new@naver.com";
+        final String verificationCode = "123abc";
+        final Email newEmail = Email.from(newEmailValue);
+        final MemberEmailUpdateRequest request = new MemberEmailUpdateRequest(newEmailValue, verificationCode);
+
+        // when
+        doReturn(Optional.of(member)).when(memberRepository)
+                .findById(memberId);
+        doReturn(false).when(memberRepository)
+                .existsByEmail(newEmail);
+        doNothing().when(mailService)
+                .verifyEmailCode(newEmailValue, verificationCode);
+        memberService.updateEmail(authPrincipal, request);
+
+        // then
+        assertThat(member.equalsEmail(newEmail)).isTrue();
+    }
+
+    @Test
+    @DisplayName("이메일 인증 코드 전송")
+    public void sendVerificationCode() throws Exception {
+        // given
+        final Long memberId = member.getId();
+        final String newEmailValue = "new@naver.com";
+        final Email newEmail = Email.from(newEmailValue);
+        final MemberEmailVerificationRequest request = new MemberEmailVerificationRequest(newEmailValue);
+
+        // when
+        doReturn(Optional.of(member)).when(memberRepository)
+                .findById(memberId);
+        doReturn(false).when(memberRepository)
+                .existsByEmail(newEmail);
+        doNothing().when(mailService)
+                .sendVerificationCode(newEmailValue);
+
+        // then
+        assertDoesNotThrow(
+                () -> memberService.sendVerificationCode(authPrincipal, request)
+        );
     }
 
     @Test

--- a/src/test/java/ject/componote/infra/mail/application/MailServiceTest.java
+++ b/src/test/java/ject/componote/infra/mail/application/MailServiceTest.java
@@ -1,0 +1,164 @@
+package ject.componote.infra.mail.application;
+
+import ject.componote.infra.mail.error.NotFoundVerificationCodeException;
+import ject.componote.infra.mail.model.VerificationCode;
+import ject.componote.infra.mail.repository.VerificationCodeRepository;
+import ject.componote.infra.mail.util.MailTemplateProvider;
+import ject.componote.infra.mail.util.VerificationCodeProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MailServiceTest {
+    @Mock
+    private JavaMailSender mailSender;
+
+    @Mock
+    private MailTemplateProvider mailTemplateProvider;
+
+    @Mock
+    private VerificationCodeProvider verificationCodeProvider;
+
+    @Mock
+    private VerificationCodeRepository verificationCodeRepository;
+
+    @Mock
+    private ExecutorService mailExecutor;
+
+    @InjectMocks
+    private MailService mailService;
+
+    @BeforeEach
+    public void setUp() {
+        mailExecutor = Executors.newFixedThreadPool(10);
+    }
+
+    @AfterEach
+    void shutdown() {
+        mailExecutor.shutdown();
+    }
+
+//    @Test
+//    @DisplayName("이메일 인증 코드 전송")
+//    void sendVerificationCode() {
+//        // given
+//        final String receiverEmail = "test@example.com";
+//        final VerificationCode verificationCode = new VerificationCode("123456", LocalDateTime.now().plusMinutes(5));
+//        final MimeMessage message = mock(MimeMessage.class);
+//
+//        doReturn(verificationCode).when(verificationCodeProvider)
+//                .createVerificationCode();
+//        doReturn("<html>Email Template</html>").when(mailTemplateProvider)
+//                .createVerificationCodeTemplate(verificationCode);
+//        doReturn(message).when(mailSender)
+//                .createMimeMessage();
+//        doNothing().when(mailSender)
+//                .send(message);
+//        doNothing().when(verificationCodeRepository)
+//                .save(receiverEmail, verificationCode);
+//
+//        // when
+//        mailService.sendVerificationCode(receiverEmail);
+//
+//        // then
+//        await().atMost(5, TimeUnit.SECONDS)
+//                .untilAsserted(
+//                        () -> {
+//                            verify(mailSender, timeout(1000)).send(any(MimeMessage.class));
+//                            verify(verificationCodeRepository, timeout(1000)).save(eq(receiverEmail), eq(verificationCode));
+//                        }
+//                );
+//    }
+
+//    @Test
+//    @DisplayName("이메일 전송 실패 시 예외 발생")
+//    void sendVerificationCodeWhenEmailSendingFail() {
+//        // given
+//        final String receiverEmail = "test@example.com";
+//        final VerificationCode verificationCode = new VerificationCode("123456", LocalDateTime.now().plusMinutes(5));
+//        final MimeMessage message = mock(MimeMessage.class);
+//
+//        doReturn(verificationCode).when(verificationCodeProvider)
+//                .createVerificationCode();
+//        doReturn("<html>Email Template</html>").when(mailTemplateProvider)
+//                .createVerificationCodeTemplate(verificationCode);
+//        doReturn(message).when(mailSender)
+//                .createMimeMessage();
+//        doThrow(new MailSendException("Failed to send")).when(mailSender)
+//                .send(any(MimeMessage.class));
+//        doNothing().when(verificationCodeRepository)
+//                .deleteByEmail(receiverEmail);
+//
+//        // when
+//        mailService.sendVerificationCode(receiverEmail);
+//
+//        // then
+//        await().atMost(2, TimeUnit.SECONDS)
+//                .untilAsserted(
+//                        () -> verify(verificationCodeRepository).deleteByEmail(receiverEmail)
+//                );
+//    }
+
+    @Test
+    @DisplayName("인증 코드 검증")
+    void verifyVerificationCode() {
+        // given
+        final String receiverEmail = "test@example.com";
+        final VerificationCode verificationCode = new VerificationCode("123456", LocalDateTime.now().plusMinutes(5));
+
+        doReturn(Optional.of(verificationCode)).when(verificationCodeRepository)
+                .findByEmail(receiverEmail);
+
+        // when
+        mailService.verifyEmailCode(receiverEmail, "123456");
+
+        // then
+        verify(verificationCodeRepository).deleteByEmail(receiverEmail);
+    }
+
+    @Test
+    @DisplayName("인증 코드가 잘못된 경우 예외 발생")
+    void verifyVerificationCodeWhenInvalidCode() {
+        // given
+        final String receiverEmail = "test@example.com";
+        final VerificationCode verificationCode = new VerificationCode("123456", LocalDateTime.now().plusMinutes(5));
+
+        doReturn(Optional.of(verificationCode)).when(verificationCodeRepository)
+                .findByEmail(receiverEmail);
+
+        // when & then
+        assertThatThrownBy(
+                () -> mailService.verifyEmailCode(receiverEmail, "wrongcode")
+        ).isInstanceOf(NotFoundVerificationCodeException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 인증 코드의 경우 예외 발생")
+    void verifyVerificationCodeWhenNotExistsCode() {
+        // given
+        final String receiverEmail = "test@example.com";
+        doReturn(Optional.empty()).when(verificationCodeRepository)
+                .findByEmail(receiverEmail);
+
+        // when & then
+        assertThatThrownBy(
+                () -> mailService.verifyEmailCode(receiverEmail, "123456")
+        ).isInstanceOf(NotFoundVerificationCodeException.class);
+    }
+}

--- a/src/test/java/ject/componote/infra/mail/repository/impl/InMemoryVerificationCodeRepositoryTest.java
+++ b/src/test/java/ject/componote/infra/mail/repository/impl/InMemoryVerificationCodeRepositoryTest.java
@@ -1,0 +1,121 @@
+package ject.componote.infra.mail.repository.impl;
+
+import ject.componote.infra.mail.model.VerificationCode;
+import ject.componote.infra.mail.repository.VerificationCodeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryVerificationCodeRepositoryTest {
+    VerificationCodeRepository verificationCodeRepository;
+
+    @BeforeEach
+    void setUp() {
+        verificationCodeRepository = new InMemoryVerificationCodeRepository();
+    }
+
+    @Test
+    @DisplayName("인증 코드 저장")
+    public void save() throws Exception {
+        // given
+        final String email = "hello@gmail.com";
+        final VerificationCode verificationCode = new VerificationCode("123456", LocalDateTime.now().plusMinutes(5));
+
+        // when
+        verificationCodeRepository.save(email, verificationCode);
+
+        // then
+        final Optional<VerificationCode> result = verificationCodeRepository.findByEmail(email);
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isEqualTo(verificationCode);
+    }
+
+    @Test
+    @DisplayName("인증 코드 삭제")
+    public void delete() throws Exception {
+        // given
+        final String email = "hello@gmail.com";
+        final VerificationCode verificationCode = new VerificationCode("123456", LocalDateTime.now().plusMinutes(5));
+
+        // when
+        verificationCodeRepository.save(email, verificationCode);
+        verificationCodeRepository.deleteByEmail(email);
+
+        // then
+        final Optional<VerificationCode> result = verificationCodeRepository.findByEmail(email);
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이메일에 해당하는 인증 코드가 없는 경우 Optional.empty() 반환")
+    public void findByEmailWhenInvalidEmail() throws Exception {
+        // when
+        final Optional<VerificationCode> result = verificationCodeRepository.findByEmail("hello@gmail.com");
+
+        // then
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이메일에 해당하는 인증 코드가 만료된 경우 Optional.empty() 반환")
+    public void findByEmailWhenExpired() throws Exception {
+        // given
+        final String email = "hello@gmail.com";
+        final VerificationCode verificationCode = new VerificationCode("123456", LocalDateTime.now().minusMinutes(5));
+
+        // when
+        verificationCodeRepository.save(email, verificationCode);
+        final Optional<VerificationCode> result = verificationCodeRepository.findByEmail("hello@gmail.com");
+
+        // then
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("여러 개의 인증 코드 저장")
+    void shouldStoreMultipleVerificationCodes() {
+        // given & when
+        final int size = 10;
+        final String[] emails = new String[size];
+        final VerificationCode[] verificationCodes = new VerificationCode[size];
+        for (int i = 0; i < size; i++) {
+            emails[i] = "hello" + i + "@gmail.com";
+            verificationCodes[i] = new VerificationCode("123456", LocalDateTime.now().plusMinutes(5));
+            verificationCodeRepository.save(emails[i], verificationCodes[i]);
+        }
+
+        // then
+        for (int i = 0; i < size; i++) {
+            final Optional<VerificationCode> result = verificationCodeRepository.findByEmail(emails[i]);
+            assertThat(result.isPresent()).isTrue();
+            assertThat(result.get()).isEqualTo(verificationCodes[i]);
+        }
+    }
+
+    @Test
+    @DisplayName("동시성 테스트 (ConcurrentHashMap)")
+    void handleConcurrency() throws InterruptedException {
+        // given
+        final String email = "concurrent@example.com";
+        final VerificationCode verificationCode = new VerificationCode("123456", LocalDateTime.now().plusMinutes(5));
+
+        // when
+        final Runnable task = () -> verificationCodeRepository.save(email, verificationCode);
+        final Thread thread1 = new Thread(task);
+        final Thread thread2 = new Thread(task);
+        thread1.start();
+        thread2.start();
+        thread1.join();
+        thread2.join();
+
+        // then
+        final Optional<VerificationCode> result = verificationCodeRepository.findByEmail(email);
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isEqualTo(verificationCode);
+    }
+}

--- a/src/test/java/ject/componote/infra/mail/util/MailTemplateProviderTest.java
+++ b/src/test/java/ject/componote/infra/mail/util/MailTemplateProviderTest.java
@@ -1,0 +1,80 @@
+package ject.componote.infra.mail.util;
+
+import ject.componote.infra.mail.model.VerificationCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.exceptions.TemplateProcessingException;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MailTemplateProviderTest {
+    @Mock
+    TemplateEngine templateEngine;
+
+    @InjectMocks
+    MailTemplateProvider mailTemplateProvider;
+
+    @Test
+    @DisplayName("이메일 인증 코드 템플릿 생성")
+    void createVerificationCodeTemplate() {
+        // given
+        final VerificationCode verificationCode = new VerificationCode("123456", LocalDateTime.now().plusMinutes(5));
+        final String expect = "<html><body>Your Code: 123456</body></html>";
+        doReturn(expect).when(templateEngine)
+                .process(eq("email-verification"), any(Context.class));
+
+        // when
+        final String actual = mailTemplateProvider.createVerificationCodeTemplate(verificationCode);
+
+        // then
+        assertThat(expect).isEqualTo(actual);
+        verify(templateEngine).process(eq("email-verification"), any(Context.class));
+    }
+
+    @Test
+    @DisplayName("이메일 인증 코드 템플릿에 인증 코드가 포함되는지 확인")
+    void shouldContainVerificationCode() {
+        // given
+        final VerificationCode verificationCode = new VerificationCode("123456", LocalDateTime.now().plusMinutes(5));
+        final String expect = "<html><body>Your Code: 123456</body></html>";
+
+        doReturn(expect).when(templateEngine)
+                .process(eq("email-verification"), any(Context.class));
+
+        // when
+        final String actual = mailTemplateProvider.createVerificationCodeTemplate(verificationCode);
+
+        // then
+        assertThat(actual.contains("123456")).isTrue();
+    }
+
+    @Test
+    @DisplayName("템플릿 생성 실패 시 예외 처리")
+    void createVerificationCodeTemplateWithException() {
+        // given
+        final VerificationCode verificationCode = new VerificationCode("123456", LocalDateTime.now().plusMinutes(5));
+        doThrow(new TemplateProcessingException("Template Error")).when(templateEngine)
+                .process(anyString(), any(Context.class));
+
+        // when & then
+        assertThatThrownBy(
+                () -> mailTemplateProvider.createVerificationCodeTemplate(verificationCode)
+        ).isInstanceOf(TemplateProcessingException.class);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 간단 회원 조회 (`GET /members/summary`) 응답 Body 수정
  - 이메일 등록 여부 필드 (`isEmailRegistered`) 추가
- HTTP Request Body가 비어있는 경우 예외 처리 추가
  - `GlobalExceptionHandler.handleHttpMessageNotReadableException()` 참고 
- 아래 라이브러리 의존성 추가
  - `spring-boot-starter-thymeleaf`: 인증 코드 HTML 메시지 동적 생성 (`MailTemplateProvider` 참고)
  - `spring-boot-starter-mail`: 메일 전송 라이브러리
- 이메일 인증 코드 전송, 확인 API 구현
  - 인증 코드는 인메모리 방식으로 저장 (`InMemoryVerificationCodeRepository` 참고)
    - Repository 인터페이스화 (`VerificationCodeRepository`)
    - 추후 Redis 도입 예정 (`RedisVerificationCodeRepository` 추가 예정)
  - 메일 전송, 인증 코드 저장: 비동기 처리 (`CompletableFuture.runAsync()`)
    - 별도 스레드풀 (`mailExecutor`) 사용 (`MailConfig`, `MailService` 참고)
    - 실패 시 롤백 및 로깅 수행
  - `MimeMessage` 를 통해 HTML 메시지 생성

## 테스트
### Repository
- 작성 중
### Service
- 작성 중
### Controller
__인증 코드 전송__
<img width="978" alt="image" src="https://github.com/user-attachments/assets/419f08b4-6ec8-425c-a9ff-3a1b87fefa7d" />

__인증 코드 확인__
<img width="885" alt="image" src="https://github.com/user-attachments/assets/e3cfe50c-bb5a-44a3-8d2c-bee53db8d0a2" />
<img width="1001" alt="image" src="https://github.com/user-attachments/assets/a67e3385-09b4-4b7b-866b-ccfbcc6cfa60" />


## 기타 사항 (참고 자료, 문의 사항 등)
### 문의 사항
API 엔드 포인트 설계가 애매합니다 ㅜㅜ
- 인증 코드 전송: POST `/auth/email/verification`
- 인증 코드 확인 + 이메일 등록/수정: PUT `/auth/email`
 뭔가 딱 이거다 싶은 엔드포인트가 생각나질 않네요,,, 추천 부탁드립니다...!

### 참고
- `MailService` 로직이 많이 복잡합니다... 이해 안가는 부분 있으면 댓글 남겨주세요!
- `build.gradle`, `resources/templates` 에 변경 사항이 있습니다! 디스코드로 보내드릴게요!