### PR TITLE
J01 58 be 알림 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
 
+### QClass ###
+**/src/main/generated
+
 ### IntelliJ IDEA ###
 .idea
 *.iws

--- a/src/main/java/ject/componote/domain/auth/domain/Member.java
+++ b/src/main/java/ject/componote/domain/auth/domain/Member.java
@@ -95,4 +95,8 @@ public class Member extends BaseEntity {
     public void updateEmail(final Email email) {
         this.email = email;
     }
+
+    public boolean hasEmail() {
+        return this.email != null;
+    }
 }

--- a/src/main/java/ject/componote/domain/comment/api/CommentController.java
+++ b/src/main/java/ject/componote/domain/comment/api/CommentController.java
@@ -83,24 +83,6 @@ public class CommentController {
                 .build();
     }
 
-    @PostMapping("/comments/{commentId}/likes")
-    @User
-    public ResponseEntity<Void> likeComment(@Authenticated final AuthPrincipal authPrincipal,
-                                            @PathVariable("commentId") final Long commentId) {
-        commentService.likeComment(authPrincipal, commentId);
-        return ResponseEntity.noContent()
-                .build();
-    }
-
-    @DeleteMapping("/comments/{commentId}/likes")
-    @User
-    public ResponseEntity<Void> unlikeComment(@Authenticated final AuthPrincipal authPrincipal,
-                                              @PathVariable("commentId") final Long commentId) {
-        commentService.unlikeComment(authPrincipal, commentId);
-        return ResponseEntity.noContent()
-                .build();
-    }
-
     @DeleteMapping("/comments/{commentId}")
     @User
     public ResponseEntity<Void> delete(@Authenticated final AuthPrincipal authPrincipal,

--- a/src/main/java/ject/componote/domain/comment/api/CommentLikeController.java
+++ b/src/main/java/ject/componote/domain/comment/api/CommentLikeController.java
@@ -1,0 +1,38 @@
+package ject.componote.domain.comment.api;
+
+import ject.componote.domain.auth.model.AuthPrincipal;
+import ject.componote.domain.auth.model.Authenticated;
+import ject.componote.domain.auth.model.User;
+import ject.componote.domain.comment.application.CommentLikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/comment-likes/{commentId}")
+@RequiredArgsConstructor
+@RestController
+public class CommentLikeController {
+    private final CommentLikeService commentLikeService;
+
+    @PostMapping
+    @User
+    public ResponseEntity<Void> likeComment(@Authenticated final AuthPrincipal authPrincipal,
+                                            @PathVariable("commentId") final Long commentId) {
+        commentLikeService.likeComment(authPrincipal, commentId);
+        return ResponseEntity.noContent()
+                .build();
+    }
+
+    @DeleteMapping
+    @User
+    public ResponseEntity<Void> unlikeComment(@Authenticated final AuthPrincipal authPrincipal,
+                                              @PathVariable("commentId") final Long commentId) {
+        commentLikeService.unlikeComment(authPrincipal, commentId);
+        return ResponseEntity.noContent()
+                .build();
+    }
+}

--- a/src/main/java/ject/componote/domain/comment/application/CommentLikeEventListener.java
+++ b/src/main/java/ject/componote/domain/comment/application/CommentLikeEventListener.java
@@ -1,22 +1,27 @@
 package ject.componote.domain.comment.application;
 
-import ject.componote.domain.comment.domain.Comment;
-import ject.componote.domain.comment.domain.CommentLike;
 import ject.componote.domain.comment.dao.CommentLikeRepository;
 import ject.componote.domain.comment.dao.CommentRepository;
+import ject.componote.domain.comment.domain.Comment;
+import ject.componote.domain.comment.domain.CommentLike;
 import ject.componote.domain.comment.dto.like.event.CommentLikeEvent;
+import ject.componote.domain.comment.dto.like.event.CommentLikeNotificationEvent;
 import ject.componote.domain.comment.dto.like.event.CommentUnlikeEvent;
 import ject.componote.domain.comment.error.NotFoundCommentException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
 @Component
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CommentLikeEventListener {
+    private final ApplicationEventPublisher eventPublisher;
     private final CommentRepository commentRepository;
     private final CommentLikeRepository commentLikeRepository;
 
@@ -30,7 +35,10 @@ public class CommentLikeEventListener {
 
         final Long memberId = event.memberId();
         commentLikeRepository.save(CommentLike.of(commentId, memberId));
-        commentRepository.save(comment);
+
+        if (!isSelfLiked(comment, memberId)) {
+            eventPublisher.publishEvent(CommentLikeNotificationEvent.of(comment, memberId));;
+        }
     }
 
     @Async
@@ -49,5 +57,9 @@ public class CommentLikeEventListener {
     private Comment findCommentById(final Long commentId) {
         return commentRepository.findById(commentId)
                 .orElseThrow(() -> new NotFoundCommentException(commentId));
+    }
+
+    private boolean isSelfLiked(final Comment comment, final Long memberId) {
+        return Objects.equals(comment.getMemberId(), memberId);
     }
 }

--- a/src/main/java/ject/componote/domain/comment/application/CommentLikeNotificationEventListener.java
+++ b/src/main/java/ject/componote/domain/comment/application/CommentLikeNotificationEventListener.java
@@ -23,9 +23,13 @@ public class CommentLikeNotificationEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleLikeNotificationEvent(final CommentLikeNotificationEvent event) {
-        final Member sender = findMemberById(event.senderId());
         final Member receiver = findMemberById(event.receiverId());
         final Comment comment = findCommentById(event.commentId()); // 추후, 댓글 내용을 알림에 포함할 수 있으므로 SELECT 수행
+        if (!receiver.hasEmail()) {
+            return;
+        }
+
+        final Member sender = findMemberById(event.senderId());
         notificationProducer.sendCommentLikeNotification(
                 CommentLikeNotificationCreateRequest.of(sender, receiver, comment)
         );

--- a/src/main/java/ject/componote/domain/comment/application/CommentLikeNotificationEventListener.java
+++ b/src/main/java/ject/componote/domain/comment/application/CommentLikeNotificationEventListener.java
@@ -1,0 +1,43 @@
+package ject.componote.domain.comment.application;
+
+import ject.componote.domain.auth.dao.MemberRepository;
+import ject.componote.domain.auth.domain.Member;
+import ject.componote.domain.auth.error.NotFoundMemberException;
+import ject.componote.domain.comment.dao.CommentRepository;
+import ject.componote.domain.comment.domain.Comment;
+import ject.componote.domain.comment.dto.like.event.CommentLikeNotificationEvent;
+import ject.componote.domain.comment.error.NotFoundCommentException;
+import ject.componote.infra.notification.application.NotificationProducer;
+import ject.componote.infra.notification.dto.create.request.CommentLikeNotificationCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class CommentLikeNotificationEventListener {
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final NotificationProducer notificationProducer;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleLikeNotificationEvent(final CommentLikeNotificationEvent event) {
+        final Member sender = findMemberById(event.senderId());
+        final Member receiver = findMemberById(event.receiverId());
+        final Comment comment = findCommentById(event.commentId()); // 추후, 댓글 내용을 알림에 포함할 수 있으므로 SELECT 수행
+        notificationProducer.sendCommentLikeNotification(
+                CommentLikeNotificationCreateRequest.of(sender, receiver, comment)
+        );
+    }
+
+    private Comment findCommentById(final Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundCommentException(commentId));
+    }
+
+    private Member findMemberById(final Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> NotFoundMemberException.createWhenInvalidMemberId(memberId));
+    }
+}

--- a/src/main/java/ject/componote/domain/comment/application/CommentLikeService.java
+++ b/src/main/java/ject/componote/domain/comment/application/CommentLikeService.java
@@ -1,0 +1,38 @@
+package ject.componote.domain.comment.application;
+
+import ject.componote.domain.auth.model.AuthPrincipal;
+import ject.componote.domain.comment.dao.CommentLikeRepository;
+import ject.componote.domain.comment.dto.like.event.CommentLikeEvent;
+import ject.componote.domain.comment.dto.like.event.CommentUnlikeEvent;
+import ject.componote.domain.comment.error.AlreadyLikedException;
+import ject.componote.domain.comment.error.NoLikedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentLikeService {
+    private final ApplicationEventPublisher eventPublisher;
+    private final CommentLikeRepository commentLikeRepository;
+
+    public void likeComment(final AuthPrincipal authPrincipal, final Long commentId) {
+        final Long memberId = authPrincipal.id();
+        if (isAlreadyLiked(commentId, memberId)) {
+            throw new AlreadyLikedException(commentId, memberId);
+        }
+        eventPublisher.publishEvent(CommentLikeEvent.of(authPrincipal, commentId));
+    }
+
+    public void unlikeComment(final AuthPrincipal authPrincipal, final Long commentId) {
+        final Long memberId = authPrincipal.id();
+        if (!isAlreadyLiked(commentId, memberId)) {
+            throw new NoLikedException(commentId, memberId);
+        }
+        eventPublisher.publishEvent(CommentUnlikeEvent.of(authPrincipal, commentId));
+    }
+
+    private boolean isAlreadyLiked(final Long commentId, final Long memberId) {
+        return commentLikeRepository.existsByCommentIdAndMemberId(commentId, memberId);
+    }
+}

--- a/src/main/java/ject/componote/domain/comment/application/CommentReplyCountEventHandler.java
+++ b/src/main/java/ject/componote/domain/comment/application/CommentReplyCountEventHandler.java
@@ -8,17 +8,20 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class CommentReplyCountEventHandler {
     private final CommentRepository commentRepository;
 
     @Async
     @EventListener
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCommentReplyCountIncreaseEvent(final CommentReplyCountIncreaseEvent event) {
         final Comment comment = findCommentById(event.parentId());
         comment.increaseReplyCount();

--- a/src/main/java/ject/componote/domain/comment/application/CommentReplyNotificationEventListener.java
+++ b/src/main/java/ject/componote/domain/comment/application/CommentReplyNotificationEventListener.java
@@ -1,0 +1,49 @@
+package ject.componote.domain.comment.application;
+
+import ject.componote.domain.auth.dao.MemberRepository;
+import ject.componote.domain.auth.domain.Member;
+import ject.componote.domain.auth.error.NotFoundMemberException;
+import ject.componote.domain.comment.dao.CommentRepository;
+import ject.componote.domain.comment.domain.Comment;
+import ject.componote.domain.comment.dto.reply.event.CommentReplyNotificationEvent;
+import ject.componote.domain.comment.error.NotFoundCommentException;
+import ject.componote.infra.notification.application.NotificationProducer;
+import ject.componote.infra.notification.dto.create.request.NestedReplyNotificationCreateRequest;
+import ject.componote.infra.notification.dto.create.request.RootReplyNotificationCreateRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CommentReplyNotificationEventListener {
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final NotificationProducer notificationProducer;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleReplyNotificationEvent(final CommentReplyNotificationEvent event) {
+        final Member sender = findMemberById(event.senderId());
+        final Comment parent = findCommentById(event.parentId());
+        final Member receiver = findMemberById(parent.getMemberId());
+        if (commentRepository.isRootComment(parent.getId())) {
+            notificationProducer.sendRootReplyNotification(RootReplyNotificationCreateRequest.of(sender, receiver, parent));
+            return;
+        }
+
+        notificationProducer.sendNestedReplyNotification(NestedReplyNotificationCreateRequest.of(sender, receiver, parent));
+    }
+
+    private Comment findCommentById(final Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundCommentException(commentId));
+    }
+
+    private Member findMemberById(final Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> NotFoundMemberException.createWhenInvalidMemberId(memberId));
+    }
+}

--- a/src/main/java/ject/componote/domain/comment/application/CommentReplyNotificationEventListener.java
+++ b/src/main/java/ject/componote/domain/comment/application/CommentReplyNotificationEventListener.java
@@ -26,9 +26,12 @@ public class CommentReplyNotificationEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleReplyNotificationEvent(final CommentReplyNotificationEvent event) {
-        final Member sender = findMemberById(event.senderId());
         final Comment parent = findCommentById(event.parentId());
         final Member receiver = findMemberById(parent.getMemberId());
+        if (!receiver.hasEmail()) {
+            return;
+        }
+        final Member sender = findMemberById(event.senderId());
         if (commentRepository.isRootComment(parent.getId())) {
             notificationProducer.sendRootReplyNotification(RootReplyNotificationCreateRequest.of(sender, receiver, parent));
             return;

--- a/src/main/java/ject/componote/domain/comment/application/CommentService.java
+++ b/src/main/java/ject/componote/domain/comment/application/CommentService.java
@@ -3,7 +3,6 @@ package ject.componote.domain.comment.application;
 import ject.componote.domain.auth.model.AuthPrincipal;
 import ject.componote.domain.comment.dao.CommentFindByComponentDao;
 import ject.componote.domain.comment.dao.CommentFindByParentDao;
-import ject.componote.domain.comment.dao.CommentLikeRepository;
 import ject.componote.domain.comment.dao.CommentRepository;
 import ject.componote.domain.comment.domain.Comment;
 import ject.componote.domain.comment.dto.create.request.CommentCreateRequest;
@@ -11,12 +10,9 @@ import ject.componote.domain.comment.dto.create.response.CommentCreateResponse;
 import ject.componote.domain.comment.dto.find.response.CommentFindByComponentResponse;
 import ject.componote.domain.comment.dto.find.response.CommentFindByMemberResponse;
 import ject.componote.domain.comment.dto.find.response.CommentFindByParentResponse;
-import ject.componote.domain.comment.dto.like.event.CommentLikeEvent;
-import ject.componote.domain.comment.dto.like.event.CommentUnlikeEvent;
 import ject.componote.domain.comment.dto.reply.event.CommentReplyCountIncreaseEvent;
+import ject.componote.domain.comment.dto.reply.event.CommentReplyNotificationEvent;
 import ject.componote.domain.comment.dto.update.request.CommentUpdateRequest;
-import ject.componote.domain.comment.error.AlreadyLikedException;
-import ject.componote.domain.comment.error.NoLikedException;
 import ject.componote.domain.comment.error.NotFoundCommentException;
 import ject.componote.domain.comment.error.NotFoundParentCommentException;
 import ject.componote.domain.comment.model.CommentContent;
@@ -45,8 +41,12 @@ public class CommentService {
         final Comment comment = commentRepository.save(
                 CommentCreationStrategy.createBy(request, authPrincipal.id())
         );
-        increaseParentReplyCount(request);
         fileService.moveImage(comment.getImage());
+
+        if (isReply(request)) {
+            eventPublisher.publishEvent(CommentReplyCountIncreaseEvent.from(comment));
+            eventPublisher.publishEvent(CommentReplyNotificationEvent.from(comment));
+        }
         return CommentCreateResponse.from(comment);
     }
 
@@ -66,8 +66,8 @@ public class CommentService {
     }
 
     public PageResponse<CommentFindByParentResponse> getRepliesByComponentId(final AuthPrincipal authPrincipal,
-                                                   final Long parentId,
-                                                   final Pageable pageable) {
+                                                                             final Long parentId,
+                                                                             final Pageable pageable) {
         final Page<CommentFindByParentResponse> page = findCommentsByParentId(authPrincipal, parentId, pageable)
                 .map(CommentFindByParentResponse::from);
         return PageResponse.from(page);
@@ -85,8 +85,6 @@ public class CommentService {
 
         final CommentContent content = CommentContent.from(commentUpdateRequest.content()); // 가비지가 발생하지 않을까?
         comment.update(content, image);
-
-        commentRepository.save(comment);
     }
 
     @CommenterValidation
@@ -133,18 +131,5 @@ public class CommentService {
         if (!commentRepository.existsById(parentId)) {
             throw new NotFoundParentCommentException(parentId);
         }
-    }
-
-    private void increaseParentReplyCount(final CommentCreateRequest request) {
-        if (!isReply(request)) {
-            return;
-        }
-
-        final Long parentId = request.parentId();
-        eventPublisher.publishEvent(CommentReplyCountIncreaseEvent.from(parentId));
-    }
-
-    private boolean isAlreadyLiked(final Long commentId, final Long memberId) {
-        return commentLikeRepository.existsByCommentIdAndMemberId(commentId, memberId);
     }
 }

--- a/src/main/java/ject/componote/domain/comment/application/CommentService.java
+++ b/src/main/java/ject/componote/domain/comment/application/CommentService.java
@@ -37,7 +37,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommentService {
     private final ApplicationEventPublisher eventPublisher;
     private final CommentRepository commentRepository;
-    private final CommentLikeRepository commentLikeRepository;
     private final FileService fileService;
 
     @Transactional
@@ -94,24 +93,6 @@ public class CommentService {
     @Transactional
     public void delete(final AuthPrincipal authPrincipal, final Long commentId) {
         commentRepository.deleteByIdAndMemberId(commentId, authPrincipal.id());
-    }
-
-    public void likeComment(final AuthPrincipal authPrincipal, final Long commentId) {
-        final Long memberId = authPrincipal.id();
-        if (isAlreadyLiked(commentId, memberId)) {
-            throw new AlreadyLikedException(commentId, memberId);
-        }
-
-        eventPublisher.publishEvent(CommentLikeEvent.of(authPrincipal, commentId));
-    }
-
-    public void unlikeComment(final AuthPrincipal authPrincipal, final Long commentId) {
-        final Long memberId = authPrincipal.id();
-        if (!isAlreadyLiked(commentId, memberId)) {
-            throw new NoLikedException(commentId, memberId);
-        }
-
-        eventPublisher.publishEvent(CommentUnlikeEvent.of(authPrincipal, commentId));
     }
 
     private Comment findCommentByIdAndMemberId(final Long commentId, final Long memberId) {

--- a/src/main/java/ject/componote/domain/comment/dao/CommentQueryDsl.java
+++ b/src/main/java/ject/componote/domain/comment/dao/CommentQueryDsl.java
@@ -9,4 +9,5 @@ public interface CommentQueryDsl {
     Page<CommentFindByParentDao> findAllByParentIdWithPagination(final Long parentId, final Pageable pageable);
     Page<CommentFindByParentDao> findAllByParentIdWithLikeStatusAndPagination(final Long parentId, final Long memberId, final Pageable pageable);
     Page<CommentFindByMemberDao> findAllByMemberIdWithPagination(final Long memberId, final Pageable pageable);
+    boolean isRootComment(final Long id);
 }

--- a/src/main/java/ject/componote/domain/comment/dao/CommentQueryDslImpl.java
+++ b/src/main/java/ject/componote/domain/comment/dao/CommentQueryDslImpl.java
@@ -80,6 +80,17 @@ public class CommentQueryDslImpl implements CommentQueryDsl {
         return toPage(baseQuery, countQuery, comment, pageable);
     }
 
+    @Override
+    public boolean isRootComment(final Long id) {
+        final Integer fetchOne = queryFactory.selectOne()
+                .from(comment)
+                .where(
+                        eqExpression(comment.id, id).and(comment.parentId.isNull())
+                )
+                .fetchOne();
+        return fetchOne != null;
+    }
+
     private JPAQuery<Long> createCountQuery(final BooleanExpression predicate) {
         return queryFactory.select(comment.count())
                 .from(comment)

--- a/src/main/java/ject/componote/domain/comment/domain/Comment.java
+++ b/src/main/java/ject/componote/domain/comment/domain/Comment.java
@@ -17,7 +17,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.DynamicUpdate;
 
+@DynamicUpdate
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/ject/componote/domain/comment/dto/like/event/CommentLikeNotificationEvent.java
+++ b/src/main/java/ject/componote/domain/comment/dto/like/event/CommentLikeNotificationEvent.java
@@ -1,0 +1,9 @@
+package ject.componote.domain.comment.dto.like.event;
+
+import ject.componote.domain.comment.domain.Comment;
+
+public record CommentLikeNotificationEvent(Long senderId, Long receiverId, Long commentId) {
+    public static CommentLikeNotificationEvent of(final Comment comment, final Long senderId) {
+        return new CommentLikeNotificationEvent(senderId, comment.getMemberId(), comment.getId());
+    }
+}

--- a/src/main/java/ject/componote/domain/comment/dto/reply/event/CommentReplyCountIncreaseEvent.java
+++ b/src/main/java/ject/componote/domain/comment/dto/reply/event/CommentReplyCountIncreaseEvent.java
@@ -3,7 +3,7 @@ package ject.componote.domain.comment.dto.reply.event;
 import ject.componote.domain.comment.domain.Comment;
 
 public record CommentReplyCountIncreaseEvent(Long parentId) {
-    public static CommentReplyCountIncreaseEvent from(final Comment comment) {
-        return new CommentReplyCountIncreaseEvent(comment.getParentId());
+    public static CommentReplyCountIncreaseEvent from(final Comment reply) {
+        return new CommentReplyCountIncreaseEvent(reply.getParentId());
     }
 }

--- a/src/main/java/ject/componote/domain/comment/dto/reply/event/CommentReplyCountIncreaseEvent.java
+++ b/src/main/java/ject/componote/domain/comment/dto/reply/event/CommentReplyCountIncreaseEvent.java
@@ -1,7 +1,9 @@
 package ject.componote.domain.comment.dto.reply.event;
 
+import ject.componote.domain.comment.domain.Comment;
+
 public record CommentReplyCountIncreaseEvent(Long parentId) {
-    public static CommentReplyCountIncreaseEvent from(final Long parentId) {
-        return new CommentReplyCountIncreaseEvent(parentId);
+    public static CommentReplyCountIncreaseEvent from(final Comment comment) {
+        return new CommentReplyCountIncreaseEvent(comment.getParentId());
     }
 }

--- a/src/main/java/ject/componote/domain/comment/dto/reply/event/CommentReplyNotificationEvent.java
+++ b/src/main/java/ject/componote/domain/comment/dto/reply/event/CommentReplyNotificationEvent.java
@@ -3,7 +3,7 @@ package ject.componote.domain.comment.dto.reply.event;
 import ject.componote.domain.comment.domain.Comment;
 
 public record CommentReplyNotificationEvent(Long senderId, Long parentId, Long commentId) {
-    public static CommentReplyNotificationEvent from(final Comment comment) {
-        return new CommentReplyNotificationEvent(comment.getMemberId(), comment.getParentId(), comment.getId());
+    public static CommentReplyNotificationEvent from(final Comment reply) {
+        return new CommentReplyNotificationEvent(reply.getMemberId(), reply.getParentId(), reply.getId());
     }
 }

--- a/src/main/java/ject/componote/domain/comment/dto/reply/event/CommentReplyNotificationEvent.java
+++ b/src/main/java/ject/componote/domain/comment/dto/reply/event/CommentReplyNotificationEvent.java
@@ -1,0 +1,9 @@
+package ject.componote.domain.comment.dto.reply.event;
+
+import ject.componote.domain.comment.domain.Comment;
+
+public record CommentReplyNotificationEvent(Long senderId, Long parentId, Long commentId) {
+    public static CommentReplyNotificationEvent from(final Comment comment) {
+        return new CommentReplyNotificationEvent(comment.getMemberId(), comment.getParentId(), comment.getId());
+    }
+}

--- a/src/main/java/ject/componote/infra/config/RabbitMqConfig.java
+++ b/src/main/java/ject/componote/infra/config/RabbitMqConfig.java
@@ -1,0 +1,77 @@
+package ject.componote.infra.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Exchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMqConfig {
+    @Bean
+    public Queue imageMoveQueue() {
+        return new Queue("imageMoveQueue");
+    }
+
+    @Bean
+    public Queue imageDeleteQueue() {
+        return new Queue("imageDeleteQueue");
+    }
+
+    @Bean
+    public Exchange imageExchange() {
+        return new TopicExchange("was-storage");
+    }
+
+    @Bean
+    public Binding imageMoveBinding(final Queue imageMoveQueue, final Exchange imageExchange) {
+        return BindingBuilder.bind(imageMoveQueue)
+                .to(imageExchange)
+                .with("storage.image.move")
+                .noargs();
+    }
+
+    @Bean
+    public Binding imageDeleteBinding(final Queue imageDeleteQueue, final Exchange imageExchange) {
+        return BindingBuilder.bind(imageDeleteQueue)
+                .to(imageExchange)
+                .with("storage.image.delete")
+                .noargs();
+    }
+
+    @Bean
+    public Queue notificationCreateQueue() {
+        return new Queue("notificationCreateQueue");
+    }
+
+    @Bean
+    public Exchange notificationExchange() {
+        return new TopicExchange("was-notification");
+    }
+
+    @Bean
+    public Binding notificationCreateBinding(final Queue notificationCreateQueue, final Exchange notificationExchange) {
+        return BindingBuilder.bind(notificationCreateQueue)
+                .to(notificationExchange)
+                .with("notification.create")
+                .noargs();
+    }
+
+    @Bean
+    public MessageConverter messageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(final ConnectionFactory connectionFactory, final MessageConverter messageConverter) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(messageConverter);
+        return rabbitTemplate;
+    }
+}

--- a/src/main/java/ject/componote/infra/file/dto/move/response/MoveResponse.java
+++ b/src/main/java/ject/componote/infra/file/dto/move/response/MoveResponse.java
@@ -1,4 +1,0 @@
-package ject.componote.infra.file.dto.move.response;
-
-public record MoveResponse() {
-}

--- a/src/main/java/ject/componote/infra/notification/application/NotificationProducer.java
+++ b/src/main/java/ject/componote/infra/notification/application/NotificationProducer.java
@@ -1,0 +1,33 @@
+package ject.componote.infra.notification.application;
+
+import ject.componote.infra.notification.dto.create.request.CommentLikeNotificationCreateRequest;
+import ject.componote.infra.notification.dto.create.request.NestedReplyNotificationCreateRequest;
+import ject.componote.infra.notification.dto.create.request.NoticeNotificationCreateRequest;
+import ject.componote.infra.notification.dto.create.request.RootReplyNotificationCreateRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationProducer {
+    private final RabbitTemplate rabbitTemplate;
+
+    public void sendRootReplyNotification(final RootReplyNotificationCreateRequest request) {
+        rabbitTemplate.convertAndSend("was-notification", "notification.create", request);
+    }
+
+    public void sendNestedReplyNotification(final NestedReplyNotificationCreateRequest request) {
+        rabbitTemplate.convertAndSend("was-notification", "notification.create", request);   // 라우팅 키, exchange 설정 필요
+    }
+
+    public void sendNoticeNotification(final NoticeNotificationCreateRequest request) {
+        rabbitTemplate.convertAndSend("was-notification", "notification.create", request);   // 라우팅 키, exchange 설정 필요
+    }
+
+    public void sendCommentLikeNotification(final CommentLikeNotificationCreateRequest request) {
+        rabbitTemplate.convertAndSend("was-notification", "notification.create", request);   // 라우팅 키, exchange 설정 필요
+    }
+}

--- a/src/main/java/ject/componote/infra/notification/dto/create/request/CommentLikeNotificationCreateRequest.java
+++ b/src/main/java/ject/componote/infra/notification/dto/create/request/CommentLikeNotificationCreateRequest.java
@@ -6,7 +6,7 @@ import ject.componote.domain.comment.domain.Comment;
 public record CommentLikeNotificationCreateRequest(NotificationParticipant participant, Long commentId) {
     public static CommentLikeNotificationCreateRequest of(final Member sender, final Member receiver, final Comment comment) {
         return new CommentLikeNotificationCreateRequest(
-                NotificationParticipant.of(receiver, sender),
+                NotificationParticipant.of(sender, receiver),
                 comment.getId()
         );
     }

--- a/src/main/java/ject/componote/infra/notification/dto/create/request/CommentLikeNotificationCreateRequest.java
+++ b/src/main/java/ject/componote/infra/notification/dto/create/request/CommentLikeNotificationCreateRequest.java
@@ -1,0 +1,13 @@
+package ject.componote.infra.notification.dto.create.request;
+
+import ject.componote.domain.auth.domain.Member;
+import ject.componote.domain.comment.domain.Comment;
+
+public record CommentLikeNotificationCreateRequest(NotificationParticipant participant, Long commentId) {
+    public static CommentLikeNotificationCreateRequest of(final Member sender, final Member receiver, final Comment comment) {
+        return new CommentLikeNotificationCreateRequest(
+                NotificationParticipant.of(receiver, sender),
+                comment.getId()
+        );
+    }
+}

--- a/src/main/java/ject/componote/infra/notification/dto/create/request/NestedReplyNotificationCreateRequest.java
+++ b/src/main/java/ject/componote/infra/notification/dto/create/request/NestedReplyNotificationCreateRequest.java
@@ -6,7 +6,7 @@ import ject.componote.domain.comment.domain.Comment;
 public record NestedReplyNotificationCreateRequest(NotificationParticipant participant, Long commentId) {
     public static NestedReplyNotificationCreateRequest of(final Member sender, final Member receiver, final Comment comment) {
         return new NestedReplyNotificationCreateRequest(
-                NotificationParticipant.of(receiver, sender),
+                NotificationParticipant.of(sender, receiver),
                 comment.getId()
         );
     }

--- a/src/main/java/ject/componote/infra/notification/dto/create/request/NestedReplyNotificationCreateRequest.java
+++ b/src/main/java/ject/componote/infra/notification/dto/create/request/NestedReplyNotificationCreateRequest.java
@@ -1,0 +1,13 @@
+package ject.componote.infra.notification.dto.create.request;
+
+import ject.componote.domain.auth.domain.Member;
+import ject.componote.domain.comment.domain.Comment;
+
+public record NestedReplyNotificationCreateRequest(NotificationParticipant participant, Long commentId) {
+    public static NestedReplyNotificationCreateRequest of(final Member sender, final Member receiver, final Comment comment) {
+        return new NestedReplyNotificationCreateRequest(
+                NotificationParticipant.of(receiver, sender),
+                comment.getId()
+        );
+    }
+}

--- a/src/main/java/ject/componote/infra/notification/dto/create/request/NoticeNotificationCreateRequest.java
+++ b/src/main/java/ject/componote/infra/notification/dto/create/request/NoticeNotificationCreateRequest.java
@@ -1,0 +1,13 @@
+package ject.componote.infra.notification.dto.create.request;
+
+import ject.componote.domain.auth.domain.Member;
+import ject.componote.domain.notice.domain.Notice;
+
+public record NoticeNotificationCreateRequest(NotificationParticipant participant, Long noticeId) {
+    public static NoticeNotificationCreateRequest of(final Member sender, final Member receiver, final Notice notice) {
+        return new NoticeNotificationCreateRequest(
+                NotificationParticipant.of(receiver, sender),
+                notice.getId()
+        );
+    }
+}

--- a/src/main/java/ject/componote/infra/notification/dto/create/request/NoticeNotificationCreateRequest.java
+++ b/src/main/java/ject/componote/infra/notification/dto/create/request/NoticeNotificationCreateRequest.java
@@ -6,7 +6,7 @@ import ject.componote.domain.notice.domain.Notice;
 public record NoticeNotificationCreateRequest(NotificationParticipant participant, Long noticeId) {
     public static NoticeNotificationCreateRequest of(final Member sender, final Member receiver, final Notice notice) {
         return new NoticeNotificationCreateRequest(
-                NotificationParticipant.of(receiver, sender),
+                NotificationParticipant.of(sender, receiver),
                 notice.getId()
         );
     }

--- a/src/main/java/ject/componote/infra/notification/dto/create/request/NotificationParticipant.java
+++ b/src/main/java/ject/componote/infra/notification/dto/create/request/NotificationParticipant.java
@@ -1,0 +1,21 @@
+package ject.componote.infra.notification.dto.create.request;
+
+import ject.componote.domain.auth.domain.Member;
+
+public record NotificationParticipant (
+        Long senderId,
+        String senderNickname,
+        Long receiverId,
+        String receiverNickname,
+        String receiverEmail
+) {
+    public static NotificationParticipant of(final Member sender, final Member receiver) {
+        return new NotificationParticipant(
+                sender.getId(),
+                sender.getNickname().getValue(),
+                receiver.getId(),
+                receiver.getNickname().getValue(),
+                receiver.getEmail().getValue()
+        );
+    }
+}

--- a/src/main/java/ject/componote/infra/notification/dto/create/request/RootReplyNotificationCreateRequest.java
+++ b/src/main/java/ject/componote/infra/notification/dto/create/request/RootReplyNotificationCreateRequest.java
@@ -6,7 +6,7 @@ import ject.componote.domain.comment.domain.Comment;
 public record RootReplyNotificationCreateRequest(NotificationParticipant participant, Long commentId) {
     public static RootReplyNotificationCreateRequest of(final Member sender, final Member receiver, final Comment comment) {
         return new RootReplyNotificationCreateRequest(
-                NotificationParticipant.of(receiver, sender),
+                NotificationParticipant.of(sender, receiver),
                 comment.getId()
         );
     }

--- a/src/main/java/ject/componote/infra/notification/dto/create/request/RootReplyNotificationCreateRequest.java
+++ b/src/main/java/ject/componote/infra/notification/dto/create/request/RootReplyNotificationCreateRequest.java
@@ -1,0 +1,13 @@
+package ject.componote.infra.notification.dto.create.request;
+
+import ject.componote.domain.auth.domain.Member;
+import ject.componote.domain.comment.domain.Comment;
+
+public record RootReplyNotificationCreateRequest(NotificationParticipant participant, Long commentId) {
+    public static RootReplyNotificationCreateRequest of(final Member sender, final Member receiver, final Comment comment) {
+        return new RootReplyNotificationCreateRequest(
+                NotificationParticipant.of(receiver, sender),
+                comment.getId()
+        );
+    }
+}

--- a/src/test/java/ject/componote/domain/comment/application/CommentLikeNotificationEventListenerTest.java
+++ b/src/test/java/ject/componote/domain/comment/application/CommentLikeNotificationEventListenerTest.java
@@ -1,0 +1,108 @@
+package ject.componote.domain.comment.application;
+
+import ject.componote.domain.auth.dao.MemberRepository;
+import ject.componote.domain.auth.domain.Member;
+import ject.componote.domain.comment.dao.CommentRepository;
+import ject.componote.domain.comment.domain.Comment;
+import ject.componote.domain.comment.dto.like.event.CommentLikeNotificationEvent;
+import ject.componote.fixture.CommentFixture;
+import ject.componote.infra.notification.application.NotificationProducer;
+import ject.componote.infra.notification.dto.create.request.CommentLikeNotificationCreateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static ject.componote.fixture.MemberFixture.이메일O_회원;
+import static ject.componote.fixture.MemberFixture.이메일X_회원;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CommentLikeNotificationEventListenerTest {
+    @Mock
+    CommentRepository commentRepository;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    NotificationProducer notificationProducer;
+
+    @InjectMocks
+    CommentLikeNotificationEventListener commentLikeNotificationEventListener;
+
+    @ParameterizedTest
+    @DisplayName("댓글 좋아요 발생 시 메시지 발행")
+    @EnumSource(value = CommentFixture.class)
+    public void handleLikeNotificationEvent(final CommentFixture fixture) throws Exception {
+        // given
+        final Member receiver = spy(이메일O_회원.생성(1L));
+        final Member sender = spy(이메일O_회원.생성(2L));
+        doReturn(1L).when(receiver)
+                .getId();
+        doReturn(2L).when(sender)
+                .getId();
+
+        final Long senderId = sender.getId();
+        final Long receiverId = receiver.getId();
+
+        final Comment comment = fixture.생성(receiverId);
+        final Long commentId = comment.getId();
+
+        final CommentLikeNotificationEvent event = CommentLikeNotificationEvent.of(comment, senderId);
+        final CommentLikeNotificationCreateRequest request = CommentLikeNotificationCreateRequest.of(sender, receiver, comment);
+
+        // when
+        doReturn(Optional.of(sender)).when(memberRepository)
+                .findById(senderId);
+        doReturn(Optional.of(receiver)).when(memberRepository)
+                .findById(receiverId);
+        doReturn(Optional.of(comment)).when(commentRepository)
+                .findById(commentId);
+        doNothing().when(notificationProducer).sendCommentLikeNotification(request);
+        
+        // then
+        commentLikeNotificationEventListener.handleLikeNotificationEvent(event);
+        verify(notificationProducer, timeout(1000))
+                .sendCommentLikeNotification(request);
+    }
+
+    @ParameterizedTest
+    @DisplayName("댓글 좋아요 발생 시 이메일이 없는 회원은 메시지 발행 X")
+    @EnumSource(value = CommentFixture.class)
+    public void handleLikeNotificationEventWhenReceiverHasNoEmail(final CommentFixture fixture) throws Exception {
+        // given
+        final Member sender = 이메일X_회원.생성(2L);
+        final Member receiver = 이메일X_회원.생성(2L);
+
+        final Long senderId = sender.getId();
+        final Long receiverId = receiver.getId();
+
+        final Comment comment = fixture.생성(receiverId);
+        final Long commentId = comment.getId();
+
+        final CommentLikeNotificationEvent event = CommentLikeNotificationEvent.of(comment, senderId);
+
+        // when
+        doReturn(Optional.of(receiver)).when(memberRepository)
+                .findById(receiverId);
+        doReturn(Optional.of(comment)).when(commentRepository)
+                .findById(commentId);
+
+        // then
+        commentLikeNotificationEventListener.handleLikeNotificationEvent(event);
+        verify(notificationProducer, never())
+                .sendCommentLikeNotification(any());
+    }
+}

--- a/src/test/java/ject/componote/domain/comment/application/CommentLikeServiceTest.java
+++ b/src/test/java/ject/componote/domain/comment/application/CommentLikeServiceTest.java
@@ -1,0 +1,120 @@
+package ject.componote.domain.comment.application;
+
+import ject.componote.domain.auth.domain.Member;
+import ject.componote.domain.auth.model.AuthPrincipal;
+import ject.componote.domain.comment.dao.CommentLikeRepository;
+import ject.componote.domain.comment.domain.Comment;
+import ject.componote.domain.comment.dto.like.event.CommentLikeEvent;
+import ject.componote.domain.comment.dto.like.event.CommentUnlikeEvent;
+import ject.componote.domain.comment.error.AlreadyLikedException;
+import ject.componote.domain.comment.error.NoLikedException;
+import ject.componote.fixture.CommentFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static ject.componote.fixture.MemberFixture.KIM;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class CommentLikeServiceTest {
+    @Mock
+    ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    CommentLikeRepository commentLikeRepository;
+
+    @InjectMocks
+    CommentLikeService commentLikeService;
+
+    final Member member = KIM.생성(1L);
+    final AuthPrincipal authPrincipal = AuthPrincipal.from(member);
+
+    @ParameterizedTest
+    @DisplayName("댓글 좋아요")
+    @EnumSource(value = CommentFixture.class)
+    public void likeComment(final CommentFixture fixture) throws Exception {
+        // given
+        final Comment comment = fixture.생성();
+        final Long commentId = comment.getId();
+        final Long memberId = authPrincipal.id();
+        final CommentLikeEvent event = CommentLikeEvent.of(authPrincipal, commentId);
+
+        // when
+        doReturn(false).when(commentLikeRepository)
+                .existsByCommentIdAndMemberId(commentId, memberId);
+        doNothing().when(eventPublisher)
+                .publishEvent(event);
+
+        // then
+        assertDoesNotThrow(
+                () -> commentLikeService.likeComment(authPrincipal, commentId)
+        );
+    }
+
+    @ParameterizedTest
+    @DisplayName("댓글 좋아요 취소")
+    @EnumSource(value = CommentFixture.class)
+    public void unlikeComment(final CommentFixture fixture) throws Exception {
+        // given
+        final Comment comment = fixture.생성();
+        final Long commentId = comment.getId();
+        final Long memberId = authPrincipal.id();
+        final CommentUnlikeEvent event = CommentUnlikeEvent.of(authPrincipal, commentId);
+
+        // when
+        doReturn(true).when(commentLikeRepository)
+                .existsByCommentIdAndMemberId(commentId, memberId);
+        doNothing().when(eventPublisher)
+                .publishEvent(event);
+
+        // then
+        assertDoesNotThrow(
+                () -> commentLikeService.unlikeComment(authPrincipal, commentId)
+        );
+    }
+
+    @ParameterizedTest
+    @DisplayName("댓글 좋아요시 좋아요를 이미 좋아요를 눌렀다면 예외 발생")
+    @EnumSource(value = CommentFixture.class)
+    public void likeCommentWhenAlreadyLiked(final CommentFixture fixture) throws Exception {
+        // given
+        final Comment comment = fixture.생성();
+        final Long commentId = comment.getId();
+        final Long memberId = authPrincipal.id();
+
+        // when
+        doReturn(true).when(commentLikeRepository)
+                .existsByCommentIdAndMemberId(commentId, memberId);
+
+        // then
+        assertThatThrownBy(() -> commentLikeService.likeComment(authPrincipal, commentId))
+                .isInstanceOf(AlreadyLikedException.class);
+    }
+
+    @ParameterizedTest
+    @DisplayName("댓글 좋아요 취소시 좋아요를 누른적이 없는 경우 예외 발생")
+    @EnumSource(value = CommentFixture.class)
+    public void unlikeCommentWhenNoLike(final CommentFixture fixture) throws Exception {
+        // given
+        final Comment comment = fixture.생성();
+        final Long commentId = comment.getId();
+        final Long memberId = authPrincipal.id();
+
+        // when
+        doReturn(false).when(commentLikeRepository)
+                .existsByCommentIdAndMemberId(commentId, memberId);
+
+        // then
+        assertThatThrownBy(() -> commentLikeService.unlikeComment(authPrincipal, commentId))
+                .isInstanceOf(NoLikedException.class);
+    }
+}

--- a/src/test/java/ject/componote/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/ject/componote/domain/comment/application/CommentServiceTest.java
@@ -7,18 +7,13 @@ import ject.componote.domain.auth.model.Nickname;
 import ject.componote.domain.auth.model.ProfileImage;
 import ject.componote.domain.comment.dao.CommentFindByComponentDao;
 import ject.componote.domain.comment.dao.CommentFindByMemberDao;
-import ject.componote.domain.comment.dao.CommentLikeRepository;
 import ject.componote.domain.comment.dao.CommentRepository;
 import ject.componote.domain.comment.domain.Comment;
 import ject.componote.domain.comment.dto.create.request.CommentCreateRequest;
 import ject.componote.domain.comment.dto.create.response.CommentCreateResponse;
 import ject.componote.domain.comment.dto.find.response.CommentFindByComponentResponse;
 import ject.componote.domain.comment.dto.find.response.CommentFindByMemberResponse;
-import ject.componote.domain.comment.dto.like.event.CommentLikeEvent;
-import ject.componote.domain.comment.dto.like.event.CommentUnlikeEvent;
 import ject.componote.domain.comment.dto.update.request.CommentUpdateRequest;
-import ject.componote.domain.comment.error.AlreadyLikedException;
-import ject.componote.domain.comment.error.NoLikedException;
 import ject.componote.domain.comment.error.NotFoundParentCommentException;
 import ject.componote.domain.comment.model.CommentContent;
 import ject.componote.domain.comment.model.CommentImage;
@@ -34,7 +29,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -56,13 +50,7 @@ import static org.mockito.Mockito.doReturn;
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
     @Mock
-    ApplicationEventPublisher eventPublisher;
-
-    @Mock
     CommentRepository commentRepository;
-
-    @Mock
-    CommentLikeRepository commentLikeRepository;
 
     @Mock
     FileService fileService;
@@ -272,85 +260,5 @@ class CommentServiceTest {
         assertDoesNotThrow(
                 () -> commentService.delete(authPrincipal, commentId)
         );
-    }
-
-    @ParameterizedTest
-    @DisplayName("댓글 좋아요")
-    @EnumSource(value = CommentFixture.class)
-    public void likeComment(final CommentFixture fixture) throws Exception {
-        // given
-        final Comment comment = fixture.생성();
-        final Long commentId = comment.getId();
-        final Long memberId = authPrincipal.id();
-        final CommentLikeEvent event = CommentLikeEvent.of(authPrincipal, commentId);
-
-        // when
-        doReturn(false).when(commentLikeRepository)
-                .existsByCommentIdAndMemberId(commentId, memberId);
-        doNothing().when(eventPublisher)
-                .publishEvent(event);
-
-        // then
-        assertDoesNotThrow(
-                () -> commentService.likeComment(authPrincipal, commentId)
-        );
-    }
-
-    @ParameterizedTest
-    @DisplayName("댓글 좋아요 취소")
-    @EnumSource(value = CommentFixture.class)
-    public void unlikeComment(final CommentFixture fixture) throws Exception {
-        // given
-        final Comment comment = fixture.생성();
-        final Long commentId = comment.getId();
-        final Long memberId = authPrincipal.id();
-        final CommentUnlikeEvent event = CommentUnlikeEvent.of(authPrincipal, commentId);
-
-        // when
-        doReturn(true).when(commentLikeRepository)
-                .existsByCommentIdAndMemberId(commentId, memberId);
-        doNothing().when(eventPublisher)
-                .publishEvent(event);
-
-        // then
-        assertDoesNotThrow(
-                () -> commentService.unlikeComment(authPrincipal, commentId)
-        );
-    }
-
-    @ParameterizedTest
-    @DisplayName("댓글 좋아요시 좋아요를 이미 좋아요를 눌렀다면 예외 발생")
-    @EnumSource(value = CommentFixture.class)
-    public void likeCommentWhenAlreadyLiked(final CommentFixture fixture) throws Exception {
-        // given
-        final Comment comment = fixture.생성();
-        final Long commentId = comment.getId();
-        final Long memberId = authPrincipal.id();
-
-        // when
-        doReturn(true).when(commentLikeRepository)
-                .existsByCommentIdAndMemberId(commentId, memberId);
-
-        // then
-        assertThatThrownBy(() -> commentService.likeComment(authPrincipal, commentId))
-                .isInstanceOf(AlreadyLikedException.class);
-    }
-
-    @ParameterizedTest
-    @DisplayName("댓글 좋아요 취소시 좋아요를 누른적이 없는 경우 예외 발생")
-    @EnumSource(value = CommentFixture.class)
-    public void unlikeCommentWhenNoLike(final CommentFixture fixture) throws Exception {
-        // given
-        final Comment comment = fixture.생성();
-        final Long commentId = comment.getId();
-        final Long memberId = authPrincipal.id();
-
-        // when
-        doReturn(false).when(commentLikeRepository)
-                .existsByCommentIdAndMemberId(commentId, memberId);
-
-        // then
-        assertThatThrownBy(() -> commentService.unlikeComment(authPrincipal, commentId))
-                .isInstanceOf(NoLikedException.class);
     }
 }

--- a/src/test/java/ject/componote/fixture/MemberFixture.java
+++ b/src/test/java/ject/componote/fixture/MemberFixture.java
@@ -1,21 +1,31 @@
 package ject.componote.fixture;
 
 import ject.componote.domain.auth.domain.Member;
+import ject.componote.domain.auth.model.Email;
 
 public enum MemberFixture {
-    KIM("김민우", "DEVELOPER", "profiles/123.jpg");
+    KIM("김민우", null, "DEVELOPER", "profiles/123.jpg"),
+    이메일O_회원("김민우", "rlarla677@gmail.com", "DEVELOPER", "profiles/123.jpg"),
+    이메일X_회원("김민우", null, "DEVELOPER", "profiles/123.jpg");
 
     private final String nickname;
+    private final String email;
     private final String job;
     private final String objectKey;
 
-    MemberFixture(final String nickname, final String job, final String objectKey) {
+    MemberFixture(final String nickname, final String email, final String job, final String objectKey) {
         this.nickname = nickname;
+        this.email = email;
         this.job = job;
         this.objectKey = objectKey;
     }
 
     public Member 생성(final Long socialAccountId) {
-        return Member.of(nickname, job, objectKey, socialAccountId);
+        final Member member = Member.of(nickname, job, objectKey, socialAccountId);
+        if (this.email != null) {
+            member.updateEmail(Email.from(email));
+        }
+
+        return member;
     }
 }


### PR DESCRIPTION
## 작업 내용
- RabbitMQ 의존성 추가
- 댓글 좋아요 시 알림 서버에 메시지 전송 로직 추가
  - `CommentLikeNotificationEventListener`: 댓글 좋아요 알림 이벤트 리스너
  - `CommentLikeNotificationEvent`: 댓글 좋아요 시 좋아요 알림 이벤트
  - `CommentLikeNotificationCreateRequest`: 알림 서버에 보내는 메시지
- 대댓글 시 알림 서버에 메시지 전송 로직 추가
  - `ReplyNotificationEventListener`: 대댓글 알림 이벤트 리스너
  - 댓글에 대한 대댓글
    - `RootReplyNotificationEvent`: 댓글에 대한 대댓글 이벤트
    - `RootReplyNotificationCreateRequest`: 알림 서버에 보내는 메시지
  - 대댓글에 대한 대댓글
    - `NestedReplyNotificationEvent`: 대댓글에 대한 대댓글 이벤트
    - `NestedReplyNotificationCreateRequest`: 알림 서버에 보내는 메시지
- 공지 사항 알림 서버 메시지 전송 로직은 아직 구현 X
  - `NoticeNotificationEvent`: 공지사항 알림 이벤트
  - `NoticeNotificationCreateRequest`: 알림 서버에 보내는 메시지

## 테스트
### Repository
- 작성 중
### Service
- 작성 중
### Controller
- 작성 중

## 기타 사항 (참고 자료, 문의 사항 등)
- 메일 서버: https://github.com/JECT-Study/Componote-BE-Mail
- 알림 서버: https://github.com/JECT-Study/Componote-BE-Notification
