### PR TITLE
J01 93 be 닉네임 검증 예외 메시지 세분화

### DIFF
--- a/src/main/java/ject/componote/domain/auth/error/InvalidNicknameCharacterException.java
+++ b/src/main/java/ject/componote/domain/auth/error/InvalidNicknameCharacterException.java
@@ -1,0 +1,9 @@
+package ject.componote.domain.auth.error;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidNicknameCharacterException extends AuthException {
+    public InvalidNicknameCharacterException() {
+        super("닉네임은 특수 문자, 한글 초성, 공백을 허용하지 않습니다.", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/ject/componote/domain/auth/error/InvalidNicknameException.java
+++ b/src/main/java/ject/componote/domain/auth/error/InvalidNicknameException.java
@@ -1,9 +1,0 @@
-package ject.componote.domain.auth.error;
-
-import org.springframework.http.HttpStatus;
-
-public class InvalidNicknameException extends AuthException {
-    public InvalidNicknameException(final String value) {
-        super("닉네임이 올바르지 않습니다. 입력한 닉네임: " + value, HttpStatus.BAD_REQUEST);
-    }
-}

--- a/src/main/java/ject/componote/domain/auth/error/InvalidNicknameLengthException.java
+++ b/src/main/java/ject/componote/domain/auth/error/InvalidNicknameLengthException.java
@@ -1,0 +1,13 @@
+package ject.componote.domain.auth.error;
+
+import ject.componote.domain.auth.model.Nickname;
+import org.springframework.http.HttpStatus;
+
+public class InvalidNicknameLengthException extends AuthException {
+    public InvalidNicknameLengthException() {
+        super(
+                String.format("닉네임 길이는 %d ~ %d 글자 사이여야 합니다.", Nickname.MIN_LENGTH, Nickname.MAX_LENGTH),
+                HttpStatus.BAD_REQUEST
+        );
+    }
+}

--- a/src/main/java/ject/componote/domain/auth/error/OffensiveNicknameException.java
+++ b/src/main/java/ject/componote/domain/auth/error/OffensiveNicknameException.java
@@ -3,7 +3,7 @@ package ject.componote.domain.auth.error;
 import org.springframework.http.HttpStatus;
 
 public class OffensiveNicknameException extends AuthException {
-    public OffensiveNicknameException(final String value) {
-        super("닉네임에 금지된 단어가 포함되있습니다. 입력한 닉네임: " + value, HttpStatus.BAD_REQUEST);
+    public OffensiveNicknameException() {
+        super("닉네임에 금지된 단어가 포함되있습니다.", HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/ject/componote/domain/auth/model/Nickname.java
+++ b/src/main/java/ject/componote/domain/auth/model/Nickname.java
@@ -1,7 +1,8 @@
 package ject.componote.domain.auth.model;
 
 import ject.componote.domain.auth.domain.BadWordFilteringSingleton;
-import ject.componote.domain.auth.error.InvalidNicknameException;
+import ject.componote.domain.auth.error.InvalidNicknameLengthException;
+import ject.componote.domain.auth.error.InvalidNicknameCharacterException;
 import ject.componote.domain.auth.error.OffensiveNicknameException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -11,6 +12,10 @@ import lombok.ToString;
 @Getter
 @ToString
 public class Nickname {
+    // 예외 처리때문에 아래 상수들은 public 으로 선언
+    public static final int MIN_LENGTH = 2;
+    public static final int MAX_LENGTH = 10;
+
     private static final String NICKNAME_REGEX = "^(?!.*[ㄱ-ㅎㅏ-ㅣ])[A-Za-z0-9가-힣]{2,10}$";
 
     private final String value;
@@ -25,12 +30,16 @@ public class Nickname {
     }
 
     private void validateNickname(final String value) {
+        if (value.length() < MIN_LENGTH || value.length() > MAX_LENGTH) {
+            throw new InvalidNicknameLengthException();
+        }
+
         if (!value.matches(NICKNAME_REGEX)) {
-            throw new InvalidNicknameException(value);
+            throw new InvalidNicknameCharacterException();
         }
 
         if (BadWordFilteringSingleton.containsBadWord(value)) {
-            throw new OffensiveNicknameException(value);
+            throw new OffensiveNicknameException();
         }
     }
 }

--- a/src/test/java/ject/componote/domain/auth/model/NicknameTest.java
+++ b/src/test/java/ject/componote/domain/auth/model/NicknameTest.java
@@ -1,6 +1,7 @@
 package ject.componote.domain.auth.model;
 
-import ject.componote.domain.auth.error.InvalidNicknameException;
+import ject.componote.domain.auth.error.InvalidNicknameCharacterException;
+import ject.componote.domain.auth.error.InvalidNicknameLengthException;
 import ject.componote.domain.auth.error.OffensiveNicknameException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,7 +34,7 @@ class NicknameTest {
     })
     public void invalidLength(final String displayName, final String value) throws Exception {
         assertThatThrownBy(() -> Nickname.from(value))
-                .isInstanceOf(InvalidNicknameException.class);
+                .isInstanceOf(InvalidNicknameLengthException.class);
     }
 
     @ParameterizedTest(name = "경우: {0}, 값: {1}")
@@ -54,7 +55,7 @@ class NicknameTest {
     })
     public void invalidCharacters(final String displayName, final String value) throws Exception {
         assertThatThrownBy(() -> Nickname.from(value))
-                .isInstanceOf(InvalidNicknameException.class);
+                .isInstanceOf(InvalidNicknameCharacterException.class);
     }
 
     @ParameterizedTest(name = "경우: {0}, 값: {1}")
@@ -65,7 +66,7 @@ class NicknameTest {
     })
     public void invalidHyphenOrUnderscore(final String displayName, final String value) throws Exception {
         assertThatThrownBy(() -> Nickname.from(value))
-                .isInstanceOf(InvalidNicknameException.class);
+                .isInstanceOf(InvalidNicknameCharacterException.class);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## 작업 내용
- 닉네임 예외 상황을 아래 3가지로 구분
  - 길이가 잘못된 경우: `InvalidNicknameLengthException`
  - 초성 문자, 공백, 특수 문자가 포함된 경우: `InvalidNicknameCharacterException`
  - 비속어가 포함된 경우: `OffensiveNicknameException`

## 테스트
### Service
<img width="436" alt="image" src="https://github.com/user-attachments/assets/58fc23b1-0798-46f5-acf3-11cab30cd42e" />


## 기타 사항 (참고 자료, 문의 사항 등)
- 없음
