### PR TITLE
J01 108 be 회원 정보 수정 api 통일

### DIFF
--- a/src/main/java/ject/componote/domain/auth/api/MemberController.java
+++ b/src/main/java/ject/componote/domain/auth/api/MemberController.java
@@ -3,9 +3,8 @@ package ject.componote.domain.auth.api;
 import jakarta.validation.Valid;
 import ject.componote.domain.auth.application.MemberService;
 import ject.componote.domain.auth.dto.find.response.MemberSummaryResponse;
-import ject.componote.domain.auth.dto.update.request.MemberNicknameUpdateRequest;
-import ject.componote.domain.auth.dto.update.request.MemberProfileImageUpdateRequest;
 import ject.componote.domain.auth.dto.update.request.MemberEmailUpdateRequest;
+import ject.componote.domain.auth.dto.update.request.MemberUpdateRequest;
 import ject.componote.domain.auth.dto.verify.request.MemberEmailVerificationRequest;
 import ject.componote.domain.auth.model.AuthPrincipal;
 import ject.componote.domain.auth.model.Authenticated;
@@ -33,18 +32,10 @@ public class MemberController {
         );
     }
 
-    @PutMapping("/profile-image")
-    public ResponseEntity<Void> updateProfileImage(@Authenticated final AuthPrincipal authPrincipal,
-                                                   @RequestBody @Valid final MemberProfileImageUpdateRequest request) {
-        memberService.updateProfileImage(authPrincipal, request);
-        return ResponseEntity.noContent()
-                .build();
-    }
-
-    @PutMapping("/nickname")
-    public ResponseEntity<Void> updateNickname(@Authenticated final AuthPrincipal authPrincipal,
-                                               @RequestBody @Valid final MemberNicknameUpdateRequest request) {
-        memberService.updateNickname(authPrincipal, request);
+    @PutMapping
+    public ResponseEntity<Void> updateMember(@Authenticated final AuthPrincipal authPrincipal,
+                                             @RequestBody @Valid final MemberUpdateRequest request) {
+        memberService.updateMember(authPrincipal, request);
         return ResponseEntity.noContent()
                 .build();
     }

--- a/src/main/java/ject/componote/domain/auth/domain/Member.java
+++ b/src/main/java/ject/componote/domain/auth/domain/Member.java
@@ -96,6 +96,10 @@ public class Member extends BaseEntity {
         this.email = email;
     }
 
+    public void updateJob(final Job job) {
+        this.job = job;
+    }
+
     public boolean hasEmail() {
         return this.email != null;
     }

--- a/src/main/java/ject/componote/domain/auth/dto/update/request/MemberUpdateRequest.java
+++ b/src/main/java/ject/componote/domain/auth/dto/update/request/MemberUpdateRequest.java
@@ -1,0 +1,13 @@
+package ject.componote.domain.auth.dto.update.request;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import ject.componote.domain.auth.domain.Job;
+
+public record MemberUpdateRequest(
+        @NotBlank String nickname,
+        @NotNull Job job,
+        @Nullable String profileImageObjectKey
+        ) {
+}

--- a/src/test/java/ject/componote/domain/auth/application/MemberServiceTest.java
+++ b/src/test/java/ject/componote/domain/auth/application/MemberServiceTest.java
@@ -2,11 +2,11 @@ package ject.componote.domain.auth.application;
 
 import ject.componote.domain.auth.dao.MemberRepository;
 import ject.componote.domain.auth.dao.MemberSummaryDao;
+import ject.componote.domain.auth.domain.Job;
 import ject.componote.domain.auth.domain.Member;
 import ject.componote.domain.auth.dto.find.response.MemberSummaryResponse;
 import ject.componote.domain.auth.dto.update.request.MemberEmailUpdateRequest;
-import ject.componote.domain.auth.dto.update.request.MemberNicknameUpdateRequest;
-import ject.componote.domain.auth.dto.update.request.MemberProfileImageUpdateRequest;
+import ject.componote.domain.auth.dto.update.request.MemberUpdateRequest;
 import ject.componote.domain.auth.dto.verify.event.EmailVerificationCodeSendEvent;
 import ject.componote.domain.auth.dto.verify.request.MemberEmailVerificationRequest;
 import ject.componote.domain.auth.error.DuplicatedNicknameException;
@@ -73,41 +73,29 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("프로필 사진 변경")
-    public void updateProfileImage() throws Exception {
+    @DisplayName("회원 정보 변경")
+    public void updateMember() throws Exception {
         // given
         final Long memberId = member.getId();
-        final String newObjectKey = "new.jpg";
-        final MemberProfileImageUpdateRequest request = new MemberProfileImageUpdateRequest(newObjectKey);
-        final ProfileImage newProfileImage = ProfileImage.from(newObjectKey);
-
-        // when
-        doReturn(Optional.of(member)).when(memberRepository)
-                .findById(memberId);
-        memberService.updateProfileImage(authPrincipal, request);
-
-        // then
-        assertThat(member.equalsProfileImage(newProfileImage)).isTrue();
-    }
-
-    @Test
-    @DisplayName("닉네임 변경")
-    public void updateNickname() throws Exception {
-        // given
-        final Long memberId = member.getId();
+        final String newProfileImageObjectKey = "new.jpg";
+        final ProfileImage newProfileImage = ProfileImage.from(newProfileImageObjectKey);
         final String newNicknameValue = "newNick";
         final Nickname newNickname = Nickname.from(newNicknameValue);
-        final MemberNicknameUpdateRequest request = new MemberNicknameUpdateRequest(newNicknameValue);
+        final Job newJob = Job.DESIGNER;
+
+        final MemberUpdateRequest request = new MemberUpdateRequest(newNicknameValue, newJob, newProfileImageObjectKey);
 
         // when
         doReturn(Optional.of(member)).when(memberRepository)
                 .findById(memberId);
         doReturn(false).when(memberRepository)
                 .existsByNickname(newNickname);
-        memberService.updateNickname(authPrincipal, request);
+        memberService.updateMember(authPrincipal, request);
 
         // then
+        assertThat(member.equalsProfileImage(newProfileImage)).isTrue();
         assertThat(member.equalsNickname(newNickname)).isTrue();
+        assertThat(member.getJob() == newJob).isTrue();
     }
 
     @Test
@@ -157,13 +145,16 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("닉네임 변경 시 이미 닉네임이 존재하는 경우 예외 발생")
-    public void updateNicknameWhenAlreadyExist() throws Exception {
+    @DisplayName("회원 정보 변경 시 이미 닉네임이 존재하는 경우 예외 발생")
+    public void updateMemberWhenNicknameAlreadyExist() throws Exception {
         // given
         final Long memberId = member.getId();
+        final String newProfileImageObjectKey = "new.jpg";
+        final ProfileImage newProfileImage = ProfileImage.from(newProfileImageObjectKey);
         final String newNicknameValue = "newNick";
         final Nickname newNickname = Nickname.from(newNicknameValue);
-        final MemberNicknameUpdateRequest request = new MemberNicknameUpdateRequest(newNicknameValue);
+        final Job newJob = Job.DESIGNER;
+        final MemberUpdateRequest request = new MemberUpdateRequest(newNicknameValue, newJob, newProfileImageObjectKey);
 
         // when
         doReturn(Optional.of(member)).when(memberRepository)
@@ -172,7 +163,7 @@ class MemberServiceTest {
                 .existsByNickname(newNickname);
 
         // then
-        assertThatThrownBy(() -> memberService.updateNickname(authPrincipal, request))
+        assertThatThrownBy(() -> memberService.updateMember(authPrincipal, request))
                 .isInstanceOf(DuplicatedNicknameException.class);
     }
 }


### PR DESCRIPTION
## 작업 내용
- 프로필 사진, 닉네임, 직업 수정을 하나의 API로 제공

## 테스트
### Service
<img width="829" alt="image" src="https://github.com/user-attachments/assets/4f5c60ff-05ff-42f7-9dcb-5c6e4897e15f" />

### Controller
<img width="879" alt="image" src="https://github.com/user-attachments/assets/0ac73c3f-8224-4fe2-8843-6da9ae079cd9" />


## 기타 사항 (참고 자료, 문의 사항 등)
- 없음
